### PR TITLE
WIP: Rectangular highlighting tool

### DIFF
--- a/examples/allImageTools/index.html
+++ b/examples/allImageTools/index.html
@@ -34,6 +34,7 @@
             <button id="circleroi" type="button" class="btn">Elliptical ROI</button>
             <button id="rectangleroi" type="button" class="btn">Rectangle ROI</button>
             <button id="angle" type="button" class="btn">Angle</button>
+            <button id="highlight" type="button" class="btn">Highlight</button>
 
             <br/>
 
@@ -72,6 +73,7 @@
                         <li>Probe - Display the image x,y coordinate under cursor as well as the pixel value (stored pixel and modality)</li>
                         <li>Elliptical ROI - An elliptical ROI that shows mean, stddev and area</li>
                         <li>Rectangle ROI - A rectangular ROI that shows mean, stddev and area</li>
+                        <li>Highlight - Darkens the image around a rectangular ROI</li>
                         <li>Angle - Cobb angle tool</li>
                     </ul>
                 </li>
@@ -115,7 +117,7 @@ is used by our example image loader-->
     element.addEventListener("CornerstoneViewportUpdated", onViewportUpdated, false);
 
     var imageId = 'example://1';
-
+    
     // image enable the dicomImage element
     cornerstone.enable(element);
     cornerstone.loadImage(imageId).then(function(image) {
@@ -132,7 +134,7 @@ is used by our example image loader-->
         cornerstoneTools.ellipticalRoi.enable(element);
         cornerstoneTools.rectangleRoi.enable(element);
         cornerstoneTools.angle.enable(element);
-
+        cornerstoneTools.highlight.enable(element);
 
         // helper function used by the tool button handlers to disable the active tool
         // before making a new tool active
@@ -146,6 +148,7 @@ is used by our example image loader-->
             cornerstoneTools.ellipticalRoi.deactivate(element, 1);
             cornerstoneTools.rectangleRoi.deactivate(element, 1);
             cornerstoneTools.angle.deactivate(element, 1);
+            cornerstoneTools.highlight.deactivate(element, 1);
         }
 
         // Tool button event handlers that set the new active tool
@@ -180,6 +183,10 @@ is used by our example image loader-->
         $('#angle').click(function () {
             disableAllTools();
             cornerstoneTools.angle.activate(element, 1);
+        });
+        $('#highlight').click(function() {
+            disableAllTools();
+            cornerstoneTools.highlight.activate(element, 1);
         });
     });
 

--- a/examples/highlight/index.html
+++ b/examples/highlight/index.html
@@ -1,0 +1,113 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <!-- support for mobile touch devices -->
+    <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1, maximum-scale=1">
+
+    <!-- twitter bootstrap CSS stylesheet - not required by cornerstoneTools -->
+    <link href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css" rel="stylesheet">
+
+    <link href="../cornerstone.min.css" rel="stylesheet">
+
+</head>
+<body>
+<div class="container">
+    <div class="page-header">
+        <h1>
+            Highlight Tool Example
+        </h1>
+        <p>
+            This page contains an example of the highlight tool
+        </p>
+
+    </div>
+
+    <div class="row">
+        <div class="col-xs-2">
+            <ul class="list-group">
+                <a href="#" id="disable" class="list-group-item">Disable</a>
+                <a href="#" id="enable" class="list-group-item">Enable</a>
+                <a href="#" id="activate" class="list-group-item">Activate</a>
+                <a href="#" id="deactivate" class="list-group-item">Deactivate</a>
+            </ul>
+        </div>
+        <div class="col-xs-6">
+            <div style="width:512px;height:512px;position:relative;display:inline-block;color:white;"
+                 oncontextmenu="return false"
+                 class='cornerstone-enabled-image'
+                 unselectable='on'
+                 onselectstart='return false;'
+                 onmousedown='return false;'>
+                <div id="dicomImage"
+                     style="width:512px;height:512px;top:0px;left:0px; position:absolute;">
+                </div>
+            </div>
+        </div>
+
+    </div>
+
+</body>
+
+<!-- jquery - included to make things easier to demo, not needed or used by the cornerstone library but
+is used by our example image loader-->
+<script src="../jquery.min.js"></script>
+
+<!-- include the cornerstone library -->
+<script src="../cornerstone.min.js"></script>
+<script src="../cornerstoneMath.min.js"></script>
+
+<!-- include the cornerstone tools library -->
+<script src="../../dist/cornerstoneTools.js"></script>
+
+<!-- include special code for these examples which provides images -->
+<script src="../exampleImageLoader.js"></script>
+
+<script>
+    var element = $('#dicomImage').get(0);
+
+    var imageId = 'example://1';
+
+    // image enable the dicomImage element
+    cornerstone.enable(element);
+    cornerstoneTools.mouseInput.enable(element);
+
+    cornerstone.loadImage(imageId).then(function(image) {
+        cornerstone.displayImage(element, image);
+
+        // Enable all tools we want to use with this element
+        cornerstoneTools.highlight.activate(element, 1);
+        activate("#activate");
+
+        function activate(id)
+        {
+            $('a').removeClass('active');
+            $(id).addClass('active');
+        }
+
+        // Tool button event handlers that set the new active tool
+        $('#disable').click(function() {
+            activate("#disable");
+            cornerstoneTools.highlight.disable(element);
+            return false;
+        });
+        $('#enable').click(function() {
+            activate("#enable");
+            cornerstoneTools.highlight.enable(element);
+            return false;
+        });
+        $('#activate').click(function() {
+            activate("#activate");
+            cornerstoneTools.highlight.activate(element, 1);
+            return false;
+        });
+        $('#deactivate').click(function() {
+            activate("#deactivate");
+            cornerstoneTools.highlight.deactivate(element, 1);
+            return false;
+        });
+    });
+
+
+
+</script>
+</html>

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -35,10 +35,11 @@ module.exports = function(grunt) {
                     'src/inputSources/mouseInput.js',
                     'src/imageTools/simpleMouseButtonTool.js',
                     'src/imageTools/mouseButtonTool.js',
+                    'src/imageTools/mouseButtonRectangleTool.js',
                     'src/imageTools/mouseWheelTool.js',
                     'src/imageTools/touchDragTool.js',
                     'src/imageTools/touchPinchTool.js',
-'src/imageTools/touchTool.js',
+                    'src/imageTools/touchTool.js',
                     'src/**/*.js'
                 ],
                 dest: 'build/built.js',

--- a/src/imageTools/highlight.js
+++ b/src/imageTools/highlight.js
@@ -1,0 +1,143 @@
+var cornerstoneTools = (function ($, cornerstone, cornerstoneMath, cornerstoneTools) {
+
+    "use strict";
+
+    if(cornerstoneTools === undefined) {
+        cornerstoneTools = {};
+    }
+
+    var toolType = "highlight";
+
+    ///////// BEGIN ACTIVE TOOL ///////
+    function createNewMeasurement(mouseEventData)
+    {
+        // create the measurement data for this tool with the end handle activated
+        var measurementData = {
+            visible : true,
+            handles : {
+                start : {
+                    x : mouseEventData.currentPoints.image.x,
+                    y : mouseEventData.currentPoints.image.y,
+                    highlight: true,
+                    active: false
+                },
+                end: {
+                    x : mouseEventData.currentPoints.image.x,
+                    y : mouseEventData.currentPoints.image.y,
+                    highlight: true,
+                    active: true
+                }
+            }
+        };
+
+        return measurementData;
+    }
+    ///////// END ACTIVE TOOL ///////
+
+    function pointInsideRect(data, coords)
+    {
+        var rect = {
+            left : Math.min(data.handles.start.x, data.handles.end.x),
+            top : Math.min(data.handles.start.y, data.handles.end.y),
+            width : Math.abs(data.handles.start.x - data.handles.end.x),
+            height : Math.abs(data.handles.start.y - data.handles.end.y)
+        };
+
+        var insideBox = false;
+        if ((coords.x >= rect.left && coords.x <= (rect.left + rect.width)) &&
+            coords.y >= rect.top && coords.y <= (rect.top + rect.height)) {
+            insideBox = true;
+        }
+        return insideBox;
+    }
+
+    function pointNearTool(data, coords)
+    {
+        var rect = {
+            left : Math.min(data.handles.start.x, data.handles.end.x),
+            top : Math.min(data.handles.start.y, data.handles.end.y),
+            width : Math.abs(data.handles.start.x - data.handles.end.x),
+            height : Math.abs(data.handles.start.y - data.handles.end.y)
+        };
+
+        var distanceToPoint = cornerstoneMath.rect.distanceToPoint(rect, coords);
+        return (distanceToPoint < 5);
+    }
+
+    ///////// BEGIN IMAGE RENDERING ///////
+
+    function onImageRendered(e, eventData) {
+
+        // if we have no toolData for this element, return immediately as there is nothing to do
+        var toolData = cornerstoneTools.getToolState(e.currentTarget, toolType);
+        if(toolData === undefined) {
+            return;
+        }
+
+        // we have tool data for this elemen
+        var context = eventData.canvasContext.canvas.getContext("2d");
+        cornerstone.setToPixelCoordinateSystem(eventData.enabledElement, context);
+
+        //activation color 
+        var color=cornerstoneTools.activeToolcoordinate.getToolColor();
+
+        context.save();
+        var data = toolData.data[0];
+        
+        var selectionColor="white",
+            toolsColor="white";
+
+        //differentiate the color of activation tool
+        var rect = {
+            left : Math.min(data.handles.start.x, data.handles.end.x),
+            top : Math.min(data.handles.start.y, data.handles.end.y),
+            width : Math.abs(data.handles.start.x - data.handles.end.x),
+            height : Math.abs(data.handles.start.y - data.handles.end.y)
+        };
+
+        // draw the handles
+        context.beginPath();
+        cornerstoneTools.drawHandles(context, eventData, data.handles, color);
+        context.stroke();
+
+        // draw dark fill outside the rectangle
+        context.beginPath();
+        context.strokeStyle = "transparent";
+        context.rect(0, 0, context.canvas.clientWidth, context.canvas.clientHeight);
+        context.rect(rect.width + rect.left, rect.top, -rect.width, rect.height);
+        context.stroke();
+        context.fillStyle = "rgba(0,0,0,0.7)";
+        context.fill();
+        context.closePath();
+
+        // draw dashed stroke rectangle
+        context.beginPath();
+        context.strokeStyle = color;
+        context.lineWidth = 2.5 / eventData.viewport.scale;
+        context.setLineDash([4]);
+        context.strokeRect(rect.left, rect.top, rect.width, rect.height);
+        context.restore();
+    }
+    ///////// END IMAGE RENDERING ///////
+
+
+    // module exports
+    var preventHandleOutsideImage = true;
+
+    cornerstoneTools.highlight = cornerstoneTools.mouseButtonRectangleTool({
+        createNewMeasurement : createNewMeasurement,
+        onImageRendered: onImageRendered,
+        pointNearTool : pointNearTool,
+        pointInsideRect: pointInsideRect,
+        toolType : toolType
+    }, preventHandleOutsideImage);
+    cornerstoneTools.highlightTouch = cornerstoneTools.touchTool({
+        createNewMeasurement: createNewMeasurement,
+        onImageRendered: onImageRendered,
+        pointNearTool: pointNearTool,
+        pointInsideRect: pointInsideRect,
+        toolType: toolType
+    }, preventHandleOutsideImage);
+
+    return cornerstoneTools;
+}($, cornerstone, cornerstoneMath, cornerstoneTools));

--- a/src/imageTools/mouseButtonRectangleTool.js
+++ b/src/imageTools/mouseButtonRectangleTool.js
@@ -1,0 +1,224 @@
+var coordsData;
+var cornerstoneTools = (function ($, cornerstone, cornerstoneMath, cornerstoneTools) {
+
+    "use strict";
+
+    if(cornerstoneTools === undefined) {
+        cornerstoneTools = {};
+    }
+
+/*
+    mouseToolInterface = {
+        createNewMeasurement : function() {},
+        onImageRendered: function() {},
+        toolType : "probe",
+    };
+
+ */
+
+    function mouseButtonRectangleTool(mouseToolInterface, preventHandleOutsideImage)
+    {
+        ///////// BEGIN ACTIVE TOOL ///////
+        function addNewMeasurement(mouseEventData)
+        {
+            var measurementData = mouseToolInterface.createNewMeasurement(mouseEventData);
+
+            // associate this data with this imageId so we can render it and manipulate it
+            cornerstoneTools.addToolState(mouseEventData.element, mouseToolInterface.toolType, measurementData);
+           
+
+            // since we are dragging to another place to drop the end point, we can just activate
+            // the end point and let the moveHandle move it for us.
+            $(mouseEventData.element).off('CornerstoneToolsMouseMove', mouseMoveCallback);
+            cornerstoneTools.moveHandle(mouseEventData, measurementData.handles.end, function() {
+                if(cornerstoneTools.anyHandlesOutsideImage(mouseEventData, measurementData.handles))
+                {
+                    // delete the measurement
+                    cornerstoneTools.removeToolState(mouseEventData.element, mouseToolInterface.toolType, measurementData);
+                }
+                $(mouseEventData.element).on('CornerstoneToolsMouseMove', mouseMoveCallback);
+            }, preventHandleOutsideImage);
+        }
+
+        function mouseDownActivateCallback(e, eventData) {
+            if (cornerstoneTools.isMouseButtonEnabled(eventData.which, e.data.mouseButtonMask)) {
+                addNewMeasurement(eventData);
+                return false; // false = cases jquery to preventDefault() and stopPropagation() this event
+            }
+        }
+        ///////// END ACTIVE TOOL ///////
+
+        ///////// BEGIN DEACTIVE TOOL ///////
+
+        function mouseMoveCallback(e, eventData)
+        {
+             cornerstoneTools.activeToolcoordinate.setCoords(eventData);
+            // if a mouse button is down, do nothing
+            if(eventData.which !== 0) {
+                return;
+            }
+          
+            
+            // if we have no tool data for this element, do nothing
+            var toolData = cornerstoneTools.getToolState(eventData.element, mouseToolInterface.toolType);
+            if(toolData === undefined) {
+                return;
+            }
+            
+            // We have tool data, search through all data
+            // and see if we can activate a handle
+            var imageNeedsUpdate = false;
+            for(var i=0; i < toolData.data.length; i++) {
+                // get the cursor position in image coordinates
+                var data = toolData.data[i];
+                if(cornerstoneTools.handleActivator(data.handles, eventData.currentPoints.image, eventData.viewport.scale ) === true)
+                {
+                    imageNeedsUpdate = true;
+                }
+            }
+
+            // Handle activation status changed, redraw the image
+            if(imageNeedsUpdate === true) {
+                cornerstone.updateImage(eventData.element);
+            }
+        }
+
+        function getHandleNearImagePoint(data, coords)
+        {
+            for(var handle in data.handles) {
+                var distanceSquared = cornerstoneMath.point.distanceSquared(data.handles[handle], coords);
+                if(distanceSquared < 25)
+                {
+                    return data.handles[handle];
+                }
+            }
+        }
+
+        function mouseDownCallback(e, eventData) {
+            var data;
+
+            function handleDoneMove()
+            {
+                if(cornerstoneTools.anyHandlesOutsideImage(eventData, data.handles))
+                {
+                    // delete the measurement
+                    cornerstoneTools.removeToolState(eventData.element, mouseToolInterface.toolType, data);
+                }
+                $(eventData.element).on('CornerstoneToolsMouseMove', mouseMoveCallback);
+            }
+
+            if(cornerstoneTools.isMouseButtonEnabled(eventData.which, e.data.mouseButtonMask)) {
+                var coords = eventData.startPoints.image;
+                var toolData = cornerstoneTools.getToolState(e.currentTarget, mouseToolInterface.toolType);
+
+                var i;
+
+                // now check to see if there is a handle we can move
+                if(toolData !== undefined) {
+                    for(i=0; i < toolData.data.length; i++) {
+                        data = toolData.data[i];
+                        var handle = getHandleNearImagePoint(data, coords);
+                        if(handle !== undefined) {
+                            $(eventData.element).off('CornerstoneToolsMouseMove', mouseMoveCallback);
+                            cornerstoneTools.moveHandle(eventData, handle, handleDoneMove, preventHandleOutsideImage);
+                            e.stopImmediatePropagation();
+                            return false;
+                        }
+                    }
+                }
+
+                // Now check to see if there is a line we can move
+                // now check to see if we have a tool that we can move
+                if(toolData !== undefined && mouseToolInterface.pointInsideRect !== undefined) {
+                    for(i=0; i < toolData.data.length; i++) {
+                        data = toolData.data[i];
+                        if(mouseToolInterface.pointInsideRect(data, coords)) {
+                            $(eventData.element).off('CornerstoneToolsMouseMove', mouseMoveCallback);
+                            cornerstoneTools.moveAllHandles(e, data, toolData, false, preventHandleOutsideImage);
+                            e.stopImmediatePropagation();
+                            return false;
+                        }
+                    }
+                }
+            }
+        }
+        ///////// END DEACTIVE TOOL ///////
+
+
+
+        // not visible, not interactive
+        function disable(element)
+        {
+            $(element).off("CornerstoneImageRendered", mouseToolInterface.onImageRendered);
+            $(element).off('CornerstoneToolsMouseMove', mouseMoveCallback);
+            $(element).off('CornerstoneToolsMouseDown', mouseDownCallback);
+            $(element).off('CornerstoneToolsMouseDownActivate', mouseDownActivateCallback);
+
+            cornerstone.updateImage(element);
+        }
+
+        // visible but not interactive
+        function enable(element)
+        {
+            $(element).off("CornerstoneImageRendered", mouseToolInterface.onImageRendered);
+            $(element).off('CornerstoneToolsMouseMove', mouseMoveCallback);
+            $(element).off('CornerstoneToolsMouseDown', mouseDownCallback);
+            $(element).off('CornerstoneToolsMouseDownActivate', mouseDownActivateCallback);
+
+            $(element).on("CornerstoneImageRendered", mouseToolInterface.onImageRendered);
+
+            cornerstone.updateImage(element);
+        }
+
+        // visible, interactive and can create
+        function activate(element, mouseButtonMask) {
+            var eventData = {
+                mouseButtonMask: mouseButtonMask,
+            };
+
+            $(element).off("CornerstoneImageRendered", mouseToolInterface.onImageRendered);
+            $(element).off("CornerstoneToolsMouseMove", mouseMoveCallback);
+            $(element).off("CornerstoneToolsMouseDown", mouseDownCallback);
+            $(element).off('CornerstoneToolsMouseDownActivate', mouseDownActivateCallback);
+
+            $(element).on("CornerstoneImageRendered", mouseToolInterface.onImageRendered);
+            $(element).on("CornerstoneToolsMouseMove", eventData, mouseMoveCallback);
+            $(element).on('CornerstoneToolsMouseDown', eventData, mouseDownCallback);
+            $(element).on('CornerstoneToolsMouseDownActivate', eventData, mouseDownActivateCallback);
+
+            cornerstone.updateImage(element);
+        }
+
+        // visible, interactive
+        function deactivate(element, mouseButtonMask) {
+            var eventData = {
+                mouseButtonMask: mouseButtonMask,
+            };
+
+            $(element).off("CornerstoneImageRendered", mouseToolInterface.onImageRendered);
+            $(element).off("CornerstoneToolsMouseMove", mouseMoveCallback);
+            $(element).off("CornerstoneToolsMouseDown", mouseDownCallback);
+            $(element).off('CornerstoneToolsMouseDownActivate', mouseDownActivateCallback);
+
+            $(element).on("CornerstoneImageRendered", mouseToolInterface.onImageRendered);
+            $(element).on("CornerstoneToolsMouseMove", eventData, mouseMoveCallback);
+            $(element).on('CornerstoneToolsMouseDown', eventData, mouseDownCallback);
+
+            cornerstone.updateImage(element);
+        }
+
+        var toolInterface = {
+            enable: enable,
+            disable : disable,
+            activate: activate,
+            deactivate: deactivate
+        };
+
+        return toolInterface;
+    }
+
+    // module exports
+    cornerstoneTools.mouseButtonRectangleTool = mouseButtonRectangleTool;
+
+    return cornerstoneTools;
+}($, cornerstone, cornerstoneMath, cornerstoneTools));

--- a/src/manipulators/handleMover.js
+++ b/src/manipulators/handleMover.js
@@ -6,13 +6,32 @@ var cornerstoneTools = (function ($, cornerstone, cornerstoneTools) {
         cornerstoneTools = {};
     }
 
-    function moveHandle(mouseEventData, handle, doneMovingCallback)
+    function moveHandle(mouseEventData, handle, doneMovingCallback, preventHandleOutsideImage)
     {
         var element = mouseEventData.element;
 
         function mouseDragCallback(e, eventData) {
             handle.x = eventData.currentPoints.image.x;
             handle.y = eventData.currentPoints.image.y;
+            if (preventHandleOutsideImage)
+            {
+                if (handle.x < 0)
+                {
+                    handle.x = 0;
+                }
+                if (handle.x > eventData.image.width)
+                {
+                    handle.x = eventData.image.width;
+                }
+                if (handle.y < 0)
+                {
+                    handle.y = 0;
+                }
+                if (handle.y > eventData.image.height)
+                {
+                    handle.y = eventData.image.height;
+                }
+            }
             cornerstone.updateImage(element);
         }
         $(element).on("CornerstoneToolsMouseDrag", mouseDragCallback);

--- a/src/manipulators/moveAllHandles.js
+++ b/src/manipulators/moveAllHandles.js
@@ -8,7 +8,7 @@ var cornerstoneTools = (function ($, cornerstone, cornerstoneMath, cornerstoneTo
 
 
 
-    function moveAllHandles(e, data, toolData, deleteIfHandleOutsideImage)
+    function moveAllHandles(e, data, toolData, deleteIfHandleOutsideImage, preventHandleOutsideImage)
     {
         var mouseEventData = e;
         var element = mouseEventData.element;
@@ -19,6 +19,25 @@ var cornerstoneTools = (function ($, cornerstone, cornerstoneMath, cornerstoneTo
                 var handle = data.handles[property];
                 handle.x += eventData.deltaPoints.image.x;
                 handle.y += eventData.deltaPoints.image.y;
+                if (preventHandleOutsideImage)
+                {
+                    if (handle.x < 0)
+                    {
+                        handle.x = 0;
+                    }
+                    if (handle.x > eventData.image.width)
+                    {
+                        handle.x = eventData.image.width;
+                    }
+                    if (handle.y < 0)
+                    {
+                        handle.y = 0;
+                    }
+                    if (handle.y > eventData.image.height)
+                    {
+                        handle.y = eventData.image.height;
+                    }
+                }
             }
             cornerstone.updateImage(element);
             return false; // false = cases jquery to preventDefault() and stopPropagation() this event


### PR DESCRIPTION
Hello!

I've hacked together a highlighting tool by adding a darkening box to the canvas. It seems to work fine, but I'd like to make the handles a bit easier to see. If you know a better way to do the canvas drawing, I'm open to suggestions.

It looks like this at the moment:

![screen shot 2014-12-03 at 01 13 18](https://cloud.githubusercontent.com/assets/607793/5273597/ac168a32-7a89-11e4-9378-ed4fc770abbb.png)

The highlight box can also be moved around by clicking anywhere inside the box. There is a new "mouseButtonRectangleTool" to facilitate this, and some changes to the moveHandles and moveAllHandles to prevent the handles from going off screen, rather than just deleting them if they do.

The relevant canvas drawing section is done like this:

        context.rect(0, 0, context.canvas.clientWidth, context.canvas.clientHeight);
        context.rect(rect.width + rect.left, rect.top, -rect.width, rect.height);

The drawing clockwise and counterclockwise is done by following the second part of this StackOverflow question: http://stackoverflow.com/questions/6271419/how-to-fill-the-opposite-shape-on-canvas

Thanks!

Erik