### PR TITLE
BF: Zoom tool now works properly after rotation / flipping

### DIFF
--- a/src/imageTools/zoom.js
+++ b/src/imageTools/zoom.js
@@ -6,6 +6,32 @@ var cornerstoneTools = (function ($, cornerstone, cornerstoneTools) {
         cornerstoneTools = {};
     }
 
+    function correctShift(shift, viewport) {
+        //Apply rotations
+        if(viewport.rotation!==0) {
+            var angle = viewport.rotation * Math.PI/180;
+    
+            var cosA = Math.cos(angle);
+            var sinA = Math.sin(angle);
+    
+            var newX = shift.x * cosA - shift.y * sinA;
+            var newY = shift.x * sinA + shift.y * cosA;
+
+            shift.x = newX;
+            shift.y = newY;
+        }
+
+        //Apply Flips        
+        if(viewport.hflip) {
+            shift.x *=-1;
+        }
+        
+        if(viewport.vflip) {
+            shift.y *=-1;
+        }
+        return shift;
+    }
+
     function zoom(element, viewport, ticks)
     {
         // Calculate the new scale factor based on how far the mouse has changed
@@ -41,10 +67,14 @@ var cornerstoneTools = (function ($, cornerstone, cornerstoneTools) {
         // Now that the scale has been updated, determine the offset we need to apply to the center so we can
         // keep the original start location in the same position
         var newCoords = cornerstone.pageToPixel(eventData.element, eventData.startPoints.page.x, eventData.startPoints.page.y);
-        eventData.viewport.translation.x -= eventData.startPoints.image.x - newCoords.x;
-        eventData.viewport.translation.y -= eventData.startPoints.image.y - newCoords.y;
+        var shift = {x: eventData.startPoints.image.x - newCoords.x,
+                     y: eventData.startPoints.image.y - newCoords.y};
+
+        shift = correctShift(shift, eventData.viewport);
+        eventData.viewport.translation.x -= shift.x;
+        eventData.viewport.translation.y -= shift.y;
         cornerstone.setViewport(eventData.element, eventData.viewport);
-        return false; // false = cases jquery to preventDefault() and stopPropagation() this event
+        return false; // false = causes jquery to preventDefault() and stopPropagation() this event
     }
 
     function mouseWheelCallback(e, eventData)
@@ -55,7 +85,7 @@ var cornerstoneTools = (function ($, cornerstone, cornerstoneTools) {
 
     function touchPinchCallback(e, eventData)
     {
-        var pinchData =eventData;
+        var pinchData = eventData;
         zoom(pinchData.element, pinchData.viewport, pinchData.direction / 4);
     }
 
@@ -68,10 +98,14 @@ var cornerstoneTools = (function ($, cornerstone, cornerstoneTools) {
         // Now that the scale has been updated, determine the offset we need to apply to the center so we can
         // keep the original start location in the same position
         var newCoords = cornerstone.pageToPixel(dragData.element, dragData.startPoints.page.x, dragData.startPoints.page.y);
-        dragData.viewport.translation.x -= dragData.startPoints.image.x - newCoords.x;
-        dragData.viewport.translation.y -= dragData.startPoints.image.y - newCoords.y;
+        var shift = {x: dragData.startPoints.image.x - newCoords.x,
+                     y: dragData.startPoints.image.y - newCoords.y};
+
+        shift = correctShift(shift, dragData.viewport);
+        dragData.viewport.translation.x -= shift.x;
+        dragData.viewport.translation.y -= shift.y;
         cornerstone.setViewport(dragData.element, dragData.viewport);
-        return false; // false = cases jquery to preventDefault() and stopPropagation() this event
+        return false; // false = causes jquery to preventDefault() and stopPropagation() this event
     }
 
 


### PR DESCRIPTION
This is a small fix for the click / drag to zoom functions. The tool normally changes viewport scale and then translates the image to zoom in on the clicked location. When rotations or flips were applied to the image, however, this translation would go wrong and the image would be translated off screen.

All I've done is borrow some of the code from pageToPixel and used it to correct the translation in these cases.

The easiest way to test this is to include cornerstoneTools and add:

```javascript
cornerstoneTools.mouseInput.enable(element);
cornerstoneTools.zoom.activate(element, 1);
```

to the cornerstone example here:

https://github.com/chafey/cornerstone/blob/master/example/flip%26rotation/index.html