### PR TITLE
Cleanup of allImageTools example

### DIFF
--- a/examples/allImageTools/index.html
+++ b/examples/allImageTools/index.html
@@ -25,19 +25,21 @@
     <br>
 
     <div class="row">
-        <div class="col-xs-6">
-            <button id="enableWindowLevelTool" type="button" class="btn">WW/WC</button>
-            <button id="pan" type="button" class="btn">Pan</button>
-            <button id="zoom" type="button" class="btn">Zoom</button>
-            <button id="enableLength" type="button" class="btn">Length</button>
-            <button id="probe" type="button" class="btn">Probe</button>
-            <button id="circleroi" type="button" class="btn">Elliptical ROI</button>
-            <button id="rectangleroi" type="button" class="btn">Rectangle ROI</button>
-            <button id="angle" type="button" class="btn">Angle</button>
-            <button id="highlight" type="button" class="btn">Highlight</button>
-
+        <div class="col-xs-2">
+            <ul class="list-group">
+                <a href="#" id="enableWindowLevelTool" class="list-group-item">WW/WC</a>
+                <a href="#" id="pan" class="list-group-item">Pan</a>
+                <a href="#" id="zoom" class="list-group-item">Zoom</a>
+                <a href="#" id="enableLength" class="list-group-item">Length</a>
+                <a href="#" id="probe" class="list-group-item">Probe</a>
+                <a href="#" id="circleroi" class="list-group-item">Elliptical ROI</a>
+                <a href="#" id="rectangleroi" class="list-group-item">Rectangle ROI</a>
+                <a href="#" id="angle" class="list-group-item">Angle</a>
+                <a href="#" id="highlight" class="list-group-item">Highlight</a>
+            </ul>
             <br/>
-
+        </div>
+        <div class="col-xs-10">
             <div style="width:512px;height:512px;position:relative;display:inline-block;color:white;"
                  oncontextmenu="return false"
                  class='cornerstone-enabled-image'
@@ -47,22 +49,24 @@
                 <div id="dicomImage"
                      style="width:512px;height:512px;top:0px;left:0px; position:absolute;">
                 </div>
-                <div id="mrtopleft" style="position: absolute;top:0px; left:0px">
+                <div id="mrtopleft" style="position: absolute;top:3px; left:3px">
                     Patient Name
                 </div>
-                <div id="mrtopright" style="position: absolute;top:0px; right:0px">
+                <div id="mrtopright" style="position: absolute;top:3px; right:3px">
                     Hospital
                 </div>
-                <div id="mrbottomright" style="position: absolute;bottom:0px; right:0px">
+                <div id="mrbottomright" style="position: absolute;bottom:3px; right:3px">
                     Zoom:
                 </div>
-                <div id="mrbottomleft" style="position: absolute;bottom:0px; left:0px">
+                <div id="mrbottomleft" style="position: absolute;bottom:3px; left:3px">
                     WW/WC:
                 </div>
             </div>
         </div>
-        <div class="col-xs-6">
-            Functionality:
+    </div>
+    <div class="row">
+        <div class="col-xs-12">
+            <h3>Functionality</h3>
             <ul>
                 <li>Activation of a tool for the left mouse button
                     <ul>
@@ -87,7 +91,6 @@
             </ul>
         </div>
     </div>
-
 </body>
 
 <!-- jquery - included to make things easier to demo, not needed or used by the cornerstone library but
@@ -111,10 +114,12 @@ is used by our example image loader-->
 
     // Listen for changes to the viewport so we can update the text overlays in the corner
     function onViewportUpdated(e) {
-        $('#mrbottomleft').text("WW/WC:" + Math.round(e.detail.viewport.voi.windowWidth) + "/" + Math.round(e.detail.viewport.voi.windowCenter));
-        $('#mrbottomright').text("Zoom:" + e.detail.viewport.scale.toFixed(2));
+        var viewport = cornerstone.getViewport(e.target)
+        $('#mrbottomleft').text("WW/WC: " + Math.round(viewport.voi.windowWidth) + "/" + Math.round(viewport.voi.windowCenter));
+        $('#mrbottomright').text("Zoom: " + viewport.scale.toFixed(2));
     };
-    element.addEventListener("CornerstoneViewportUpdated", onViewportUpdated, false);
+
+    $('#dicomImage').on("CornerstoneImageRendered", onViewportUpdated);
 
     var imageId = 'example://1';
     
@@ -136,6 +141,13 @@ is used by our example image loader-->
         cornerstoneTools.angle.enable(element);
         cornerstoneTools.highlight.enable(element);
 
+        activate("#enableWindowLevelTool");
+
+        function activate(id)
+        {
+            $('a').removeClass('active');
+            $(id).addClass('active');
+        }
         // helper function used by the tool button handlers to disable the active tool
         // before making a new tool active
         function disableAllTools()
@@ -153,38 +165,47 @@ is used by our example image loader-->
 
         // Tool button event handlers that set the new active tool
         $('#enableWindowLevelTool').click(function() {
+            activate('#enableWindowLevelTool')
             disableAllTools();
             cornerstoneTools.wwwc.activate(element, 1);
         });
         $('#pan').click(function() {
+            activate('#pan')
             disableAllTools();
             cornerstoneTools.pan.activate(element, 3); // 3 means left mouse button and middle mouse button
         });
         $('#zoom').click(function() {
+            activate('#zoom')
             disableAllTools();
             cornerstoneTools.zoom.activate(element, 5); // 5 means left mouse button and right mouse button
         });
         $('#enableLength').click(function() {
+            activate('#enableLength')
             disableAllTools();
             cornerstoneTools.length.activate(element, 1);
         });
         $('#probe').click(function() {
+            activate('#probe')
             disableAllTools();
             cornerstoneTools.probe.activate(element, 1);
         });
         $('#circleroi').click(function() {
+            activate('#circleroi')
             disableAllTools();
             cornerstoneTools.ellipticalRoi.activate(element, 1);
         });
         $('#rectangleroi').click(function() {
+            activate('#rectangleroi')
             disableAllTools();
             cornerstoneTools.rectangleRoi.activate(element, 1);
         });
         $('#angle').click(function () {
+            activate('#angle')
             disableAllTools();
             cornerstoneTools.angle.activate(element, 1);
         });
         $('#highlight').click(function() {
+            activate('#highlight')
             disableAllTools();
             cornerstoneTools.highlight.activate(element, 1);
         });


### PR DESCRIPTION
This is just a bit of cleanup for the allImageTools example. It also fixes issue #19 by changing onViewportUpdated to use CornerstoneImageRendered. I'm not sure if this is appropriate, but it works and I don't see the CornerstoneViewportUpdated event in the cornerstone code anywhere

![allimagetoolsgif](https://cloud.githubusercontent.com/assets/607793/7115567/07d86292-e1ea-11e4-80e9-3c07b28bf745.gif)
.
