### PR TITLE
Example for monitoring image loading progress in a stack

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -28,6 +28,7 @@
         <li><a href="mobileTouch/index.html">MobileTouch</a> - example of using touch events</li>
         <li><a href="probe/index.html">Pixel Probe Tool</a> - example of using the pixel probe tool</li>
         <li><a href="stackScroll/index.html">Stack Scroll Tool</a> - example of using the stack scroll tool</li>
+        <li><a href="stackProgress/index.html">Stack Loading Progress</a> - example of monitoring image loading progress within a stack</li>
         <li><a href="panZoomSynchronizer/index.html">Pan/Zoom Synchronizer</a> - example of synchronizing the pan and zoom between multiple images</li>
         <li><a href="referenceLineTool/index.html">Reference Lines Tool</a> - example of displaying reference lines</li>
         <li><a href="stackImagePositionSynchronizer/index.html">Stack Image Position Synchronizer Tool</a> - example of stack synchronization tool using the image position</li>

--- a/examples/stackProgress/index.html
+++ b/examples/stackProgress/index.html
@@ -1,0 +1,128 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <!-- support for mobile touch devices -->
+    <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1, maximum-scale=1">
+
+    <!-- twitter bootstrap CSS stylesheet - not required by cornerstoneTools -->
+    <link href="../bootstrap.min.css" rel="stylesheet">
+
+    <link href="../cornerstone.min.css" rel="stylesheet">
+
+</head>
+<body>
+<div class="container">
+    <div class="page-header">
+        <h1>
+            Stack Loading Progress Example
+        </h1>
+        <p>
+            This page contains an example of monitoring percentage of images in the stack which have been loaded.
+        </p>
+        <a href="../index.html">Go back to the Examples page</a>
+    </div>
+
+    <div class="row">
+        <div class="col-xs-2">
+            <h5>Percentage loaded</h5>
+            <span id="loadProgress"></span>
+        </div>
+        <div class="col-xs-6">
+            <div style="width:512px;height:512px;position:relative;display:inline-block;color:white;"
+                 oncontextmenu="return false"
+                 class='cornerstone-enabled-image'
+                 unselectable='on'
+                 onselectstart='return false;'
+                 onmousedown='return false;'>
+                <div id="dicomImage"
+                     style="width:512px;height:512px;top:0px;left:0px; position:absolute;">
+                </div>
+            </div>
+        </div>
+
+    </div>
+
+</body>
+
+<!-- jquery - included to make things easier to demo, not needed or used by the cornerstone library but
+is used by our example image loader-->
+<script src="../jquery.min.js"></script>
+
+<!-- include the cornerstone library -->
+<script src="../cornerstone.min.js"></script>
+<script src="../cornerstoneMath.min.js"></script>
+
+<!-- include the cornerstone tools library -->
+<script src="../../dist/cornerstoneTools.js"></script>
+
+<!-- include special code for these examples which provides images -->
+<script src="../exampleImageLoader.js"></script>
+
+<script>
+    var element = $('#dicomImage').get(0);
+
+    var imageIds = [
+        'example://1',
+        'example://2',
+        'example://3'
+    ];
+
+    var stack = {
+        currentImageIdIndex : 0,
+        imageIds: imageIds
+    };
+
+
+    // Deep copy the imageIds
+    var loadProgress = {"imageIds": stack.imageIds.slice(0),
+                    "total": stack.imageIds.length,
+                    "remaining": stack.imageIds.length,
+                    "percentLoaded": 0,
+                    };
+
+    function onImageLoaded (event, args){
+        var imageId = args.image.imageId;
+        var imageIds = loadProgress["imageIds"];
+
+        // Remove all instances, in case the stack repeats imageIds
+        for(var i = imageIds.length - 1; i >= 0; i--) {
+            if(imageIds[i] === imageId) {
+               imageIds.splice(i, 1);
+            }
+        }
+
+        // Populate the load progress object
+        loadProgress["remaining"] = imageIds.length;
+        loadProgress["percentLoaded"] = parseInt(100 - loadProgress["remaining"] / loadProgress["total"] * 100, 10);
+
+        // Write to a span in the DOM
+        var currentValueSpan = document.getElementById("loadProgress");
+        currentValueSpan.textContent = loadProgress["percentLoaded"];
+    }
+
+    // Image loading events are bound to the cornerstone object, not the element
+    $(cornerstone).on("CornerstoneImageLoaded", onImageLoaded);
+
+    // image enable the dicomImage element and the mouse inputs
+    cornerstone.enable(element);
+    cornerstoneTools.mouseInput.enable(element);
+    cornerstoneTools.mouseWheelInput.enable(element);
+    cornerstone.loadImage(imageIds[0]).then(function(image) {
+        // display this image
+        cornerstone.displayImage(element, image);
+
+        // set the stack as tool state
+        cornerstoneTools.addStackStateManager(element, ['stack']);
+        cornerstoneTools.addToolState(element, 'stack', stack);
+
+        // Enable all tools we want to use with this element
+        cornerstoneTools.stackScroll.activate(element, 1);
+        cornerstoneTools.stackScrollWheel.activate(element);
+
+        // Uncomment below to enable stack prefetching
+        // With the example images the loading will be extremely quick, though
+        // cornerstoneTools.stackPrefetch.enable(element);
+    });
+
+</script>
+</html>


### PR DESCRIPTION
This came up on the google group (https://groups.google.com/forum/#!topic/cornerstone-platform/VxuF921Q42I) so I thought I'd share my implementation.

You just monitor CornerstoneImageLoaded and use an object to slice imageIds out of an array when they've been loaded.

![stackloadprogress](https://cloud.githubusercontent.com/assets/607793/7346776/00cffea8-ece2-11e4-98e1-ce5f58142bff.gif)
