### PR TITLE
Bug fix for stack prefetch ignoring 0th image

### DIFF
--- a/src/stackTools/stackPrefetch.js
+++ b/src/stackTools/stackPrefetch.js
@@ -65,7 +65,7 @@ var cornerstoneTools = (function ($, cornerstone, cornerstoneTools) {
         var stackPrefetchData = cornerstoneTools.getToolState(element, toolType);
         if(stackPrefetchData === undefined) {
             stackPrefetchData = {
-                prefetchImageIdIndex : 0,
+                prefetchImageIdIndex : -1,
                 enabled: true
             };
             cornerstoneTools.addToolState(element, toolType, stackPrefetchData);
@@ -79,7 +79,7 @@ var cornerstoneTools = (function ($, cornerstone, cornerstoneTools) {
         var stackPrefetchData = cornerstoneTools.getToolState(element, toolType);
         if(stackPrefetchData === undefined) {
             stackPrefetchData = {
-                prefetchImageIdIndex : 0,
+                prefetchImageIdIndex : -1,
                 enabled: false
             };
             cornerstoneTools.removeToolState(element, toolType, stackPrefetchData);


### PR DESCRIPTION
This is a very tiny fix for a bug that occurs when you use something like this (some stuff left out, obviously):

```` javascript
var stack = {
    currentImageIdIndex : currentImageIdIndex,
    imageIds: imageIds
};

cornerstone.loadAndCacheImage(imageIds[currentImageIdIndex])

cornerstoneTools.stackPrefetch.enable(element);
````

using any value of  ````currentImageIdIndex ```` other than 0, the prefetching would not grab the entire stack. This is because the stackPrefetch code assumed that you had already loaded ````imageIds[0]````.

Switching the initial value of ````prefetchImageIdIndex```` to -1 now forces ````imageIds[0]```` to be loaded.