### PR TITLE
missing line added

### DIFF
--- a/src/imageTools/annotation.js
+++ b/src/imageTools/annotation.js
@@ -596,5 +596,7 @@ var cornerstoneTools = (function ($, cornerstone, cornerstoneMath, cornerstoneTo
         deactivate: deactivateTouch
     };
 
+    cornerstoneTools.getConfiguration = getConfiguration;
+
     return cornerstoneTools;
 }($, cornerstone, cornerstoneMath, cornerstoneTools));


### PR DESCRIPTION
Hi Chris. I found out, at version 0.6.2 of cornerstoneTools that he is missing this line at annotation.js:

cornerstoneTools.getConfiguration = getConfiguration;

The method touchDragCallback in wwwc.js was not working because of this. It have a call for getConfiguration:

var config = cornerstoneTools.getConfiguration();

I hope it can help, I tried to post it at google groups but I'm not sure if there is the right place for this kind of thing.