### PR TITLE
Change pointNearHandle to compare distance based on screen pixels

### DIFF
--- a/src/imageTools/freehand.js
+++ b/src/imageTools/freehand.js
@@ -72,9 +72,13 @@ var cornerstoneTools = (function ($, cornerstone, cornerstoneMath, cornerstoneTo
             return;
         }
 
-        var mousePoint = eventData.currentPoints.image;
+        var mousePoint = eventData.currentPoints.page;
+        var mousePointClient = cornerstone.pageToCanvas(eventData.element, mousePoint);
+        
         for (var i=0; i < data.handles.length; i++) {
-            if (cornerstoneMath.point.distance(data.handles[i], mousePoint) < 5) {
+            var handlePointClient = cornerstone.pixelToCanvas(eventData.element, data.handles[i]);
+            var distance = cornerstoneMath.point.distance(handlePointClient, mousePointClient);
+            if (distance < 5) {
                 return i;
             }
         }


### PR DESCRIPTION
- Previous implementation compared distance based on image pixels, which changed the behavior for different image resolutions. For example, a high resolution chest radiograph will not "snap" correctly as 5 image pixels translates to <1 screen pixel when zoomed to fit.