### PR TITLE
Fix equation for calculating if point is in ellipse

### DIFF
--- a/src/imageTools/ellipticalRoi.js
+++ b/src/imageTools/ellipticalRoi.js
@@ -66,16 +66,8 @@
             x: ellipse.left + xRadius, y: ellipse.top + yRadius
         };
 
-        /* This is a more general form of the circle equation
-         *
-         * X^2/a^2 + Y^2/b^2 <= 1
-         */
-
-        var normalized = {
-            x: location.x - center.x, y: location.y - center.y
-        };
-
-        var inEllipse = ((normalized.x * normalized.y) / (xRadius * xRadius)) + ((normalized.y * normalized.y) / (yRadius * yRadius)) <= 1.0;
+        var inEllipse = (Math.pow((location.x - center.x),2) / Math.pow(xRadius, 2)) + (Math.pow((location.y - center.y),2) / Math.pow(yRadius, 2)) <= 1;
+        
         return inEllipse;
     }
 


### PR DESCRIPTION
Current equation used in pointInEllipse function has some weird behavior and does not accurately approximate the ellipse (example [here](https://rawgit.com/jmhmd/cornerstoneTools/bugfix-circle-example/examples/highlight/ellipse.html)).

Proposed fix to use a new equation which seems be more accurate (example [here](https://rawgit.com/jmhmd/cornerstoneTools/bugfix-circle-example/examples/highlight/ellipseFixed.html)).

Source of new equation: http://math.stackexchange.com/a/76463