### PR TITLE
fixed multitouch panning

### DIFF
--- a/src/inputSources/touchInput.js
+++ b/src/inputSources/touchInput.js
@@ -434,6 +434,7 @@
         // we want to detect both the same time
         pinch.recognizeWith(pan);
         pinch.recognizeWith(rotate);
+        rotate.recognizeWith(pan);
 
         var doubleTap = new Hammer.Tap({
             event: 'doubletap',


### PR DESCRIPTION
The "panmove"-Event only fires when using a single finger.
More fingers may be added while panning.

But if the panning ist started with multiple fingers, the "panmove" event doesen't fire.

Added "rotate.recognizeWith(pan);" to fix this.
Now the "panmove" event is fired when starting with multiple fingers.