### PR TITLE
Turn off on click events

### DIFF
--- a/src/imageTools/magnify.js
+++ b/src/imageTools/magnify.js
@@ -13,6 +13,7 @@
     function mouseUpCallback(e, eventData) {
         $(eventData.element).off('CornerstoneToolsMouseDrag', dragCallback);
         $(eventData.element).off('CornerstoneToolsMouseUp', mouseUpCallback);
+        $(eventData.element).off('CornerstoneToolsMouseClick', mouseUpCallback);
         hideTool(eventData);
     }
 
@@ -27,6 +28,7 @@
         if (cornerstoneTools.isMouseButtonEnabled(eventData.which, e.data.mouseButtonMask)) {
             $(eventData.element).on('CornerstoneToolsMouseDrag', eventData, dragCallback);
             $(eventData.element).on('CornerstoneToolsMouseUp', eventData, mouseUpCallback);
+            $(eventData.element).on('CornerstoneToolsMouseClick', eventData, mouseUpCallback);
             drawMagnificationTool(eventData);
             return false; // false = causes jquery to preventDefault() and stopPropagation() this event
         }


### PR DESCRIPTION
Otherwise strange behaviour occurs when the user just clicks on the image while the tool is active. For example, the cursor will stay hidden.