### PR TITLE
Fix 'element not enabled' errors.

### DIFF
--- a/src/stackTools/stackPrefetch.js
+++ b/src/stackTools/stackPrefetch.js
@@ -221,7 +221,7 @@
         // When the user has scrolled to a new image
         clearTimeout(resetPrefetchTimeout);
         resetPrefetchTimeout = setTimeout(function() {
-            var element = e.currentTarget;
+            var element = e.target;
             prefetch(element);
         }, resetPrefetchDelay);
     }


### PR DESCRIPTION
The fact that the errors were occuring for the currentTarget made me suspect I was somehow enabling the wrong element in my application, but I've done a lot of testing and I'm 99% sure this is not actually
happening.

For more information, please see this post: https://groups.google.com/forum/#!msg/cornerstone-platform/uU09JPyWJTU/1NhQXaMeBQAJ