### PR TITLE
use buttons instead of which in the mouse event api

### DIFF
--- a/src/inputSources/mouseInput.js
+++ b/src/inputSources/mouseInput.js
@@ -95,7 +95,7 @@
             }
         }
 
-        var whichMouseButton = e.which;
+        var whichMouseButton = e.buttons;
 
         function onMouseMove(e) {
             // calculate our current points in page and image coordinates
@@ -215,7 +215,7 @@
 
         var lastPoints = cornerstoneTools.copyPoints(startPoints);
 
-        var whichMouseButton = e.which;
+        var whichMouseButton = e.buttons;
 
         // calculate our current points in page and image coordinates
         var currentPoints = {


### PR DESCRIPTION
Firefox does not recommend the `which` api as it is not standard
https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/which

This closes issue #162 
