### PR TITLE
Purge image cache issue (stackPrefetch)

### DIFF
--- a/src/stackTools/stackPrefetch.js
+++ b/src/stackTools/stackPrefetch.js
@@ -176,8 +176,14 @@
         // Stop prefetching if the ImageCacheFull event is fired from cornerstone
         // console.log('CornerstoneImageCacheFull full, stopping');
         var element = e.data.element;
+        var stackPrefetchData;
 
-        var stackPrefetchData = cornerstoneTools.getToolState(element, toolType);
+        try {
+            stackPrefetchData = cornerstoneTools.getToolState(element, toolType);
+        } catch(error) {
+            return;
+        }
+
         if (!stackPrefetchData || !stackPrefetchData.data || !stackPrefetchData.data.length) {
             return;
         }

--- a/src/stackTools/stackPrefetch.js
+++ b/src/stackTools/stackPrefetch.js
@@ -194,7 +194,15 @@
         // it to the indicesToRequest list so that it will be retrieved later if the
         // currentImageIdIndex is changed to an image nearby
         var element = e.data.element;
-        var stackData = cornerstoneTools.getToolState(element, 'stack');
+        var stackData;
+
+        try {
+            // It will throw an exception in some cases (eg: thumbnails)
+            stackData = cornerstoneTools.getToolState(element, 'stack');
+        } catch(error) {
+            return;
+        }
+
         if (!stackData || !stackData.data || !stackData.data.length) {
             return;
         }


### PR DESCRIPTION
stackPrefetch should not trigger exceptions for disabled elements removed from cache