### PR TITLE
Bugfix for interactive mode in touch tools

### DIFF
--- a/src/imageTools/touchTool.js
+++ b/src/imageTools/touchTool.js
@@ -106,7 +106,7 @@
                 }
 
                 cornerstone.updateImage(element);
-                $(element).on('CornerstoneToolsTouchStartActive', touchToolInterface.touchDownActivateCallback || touchDownActivateCallback);
+                $(element).on('CornerstoneToolsTouchStart', touchToolInterface.touchStartCallback || touchStartCallback);
                 $(element).on('CornerstoneToolsTap', touchToolInterface.tapCallback || tapCallback);
             }
 
@@ -117,7 +117,7 @@
                     var distanceSq = 25; // Should probably make this a settable property later
                     var handle = cornerstoneTools.getHandleNearImagePoint(element, data.handles, coords, distanceSq);
                     if (handle) {
-                        $(element).off('CornerstoneToolsTouchStartActive', touchToolInterface.touchDownActivateCallback || touchDownActivateCallback);
+                        $(element).off('CornerstoneToolsTouchStart', touchToolInterface.touchStartCallback || touchStartCallback);
                         $(element).off('CornerstoneToolsTap', touchToolInterface.tapCallback || tapCallback);
                         data.active = true;
                         handle.active = true;
@@ -134,7 +134,7 @@
                 for (i = 0; i < toolData.data.length; i++) {
                     data = toolData.data[i];
                     if (touchToolInterface.pointNearTool(element, data, coords)) {
-                        $(element).off('CornerstoneToolsTouchStartActive', touchToolInterface.touchDownActivateCallback || touchDownActivateCallback);
+                        $(element).off('CornerstoneToolsTouchStart', touchToolInterface.touchStartCallback || touchStartCallback);
                         $(element).off('CornerstoneToolsTap', touchToolInterface.tapCallback || tapCallback);
                         data.active = true;
                         cornerstone.updateImage(element);
@@ -174,7 +174,7 @@
                 }
 
                 cornerstone.updateImage(eventData.element);
-                $(element).on('CornerstoneToolsTouchStartActive', touchToolInterface.touchDownActivateCallback || touchDownActivateCallback);
+                $(element).on('CornerstoneToolsTouchStart', touchToolInterface.touchStartCallback || touchStartCallback);
                 $(element).on('CornerstoneToolsTap', touchToolInterface.tapCallback || tapCallback);
 
                 if (touchToolInterface.pressCallback) {
@@ -201,7 +201,7 @@
 
                 var handle = cornerstoneTools.getHandleNearImagePoint(eventData.element, data.handles, coords, distance);
                 if (handle) {
-                    $(element).off('CornerstoneToolsTouchStartActive', touchToolInterface.touchDownActivateCallback || touchDownActivateCallback);
+                    $(element).off('CornerstoneToolsTouchStart', touchToolInterface.touchStartCallback || touchStartCallback);
                     $(element).off('CornerstoneToolsTap', touchToolInterface.tapCallback || tapCallback);
                     if (touchToolInterface.pressCallback) {
                         $(element).off('CornerstoneToolsTouchPress', touchToolInterface.pressCallback);
@@ -223,7 +223,7 @@
                 data = toolData.data[i];
 
                 if (touchToolInterface.pointNearTool(eventData.element, data, coords)) {
-                    $(element).off('CornerstoneToolsTouchStartActive', touchToolInterface.touchDownActivateCallback || touchDownActivateCallback);
+                    $(element).off('CornerstoneToolsTouchStart', touchToolInterface.touchStartCallback || touchStartCallback);
                     $(element).off('CornerstoneToolsTap', touchToolInterface.tapCallback || tapCallback);
                     if (touchToolInterface.pressCallback) {
                         $(element).off('CornerstoneToolsTouchPress', touchToolInterface.pressCallback);
@@ -319,6 +319,7 @@
             $(element).off('CornerstoneToolsTap', touchToolInterface.tapCallback || tapCallback);
 
             $(element).on('CornerstoneImageRendered', touchToolInterface.onImageRendered);
+            $(element).on('CornerstoneToolsTouchStart', touchToolInterface.touchStartCallback || touchStartCallback);
             //$(element).on('CornerstoneToolsTap', touchToolInterface.tapCallback || tapCallback);
 
             if (touchToolInterface.doubleTapCallback) {


### PR DESCRIPTION
It is not possible at the moment to make touch tools interactive but not creatable.
The 'CornerstoneToolsTouchStart' should be set to on if the tools is deactivated.
When a measurement is modified the 'CornerstoneToolsTouchStart' event should be used instead of the 'CornerstoneToolsTouchStartActive' to not enable the creatation of new objects