### PR TITLE
image tools: event handlers should not return 'false' when it's disabled or toolData is unavailable

### DIFF
--- a/src/imageTools/annotation.js
+++ b/src/imageTools/annotation.js
@@ -326,7 +326,7 @@
         }
 
         if (e.data && e.data.mouseButtonMask && !cornerstoneTools.isMouseButtonEnabled(eventData.which, e.data.mouseButtonMask)) {
-            return false;
+            return;
         }
 
         var config = cornerstoneTools.arrowAnnotate.getConfiguration();
@@ -375,7 +375,7 @@
         }
 
         if (e.data && e.data.mouseButtonMask && !cornerstoneTools.isMouseButtonEnabled(eventData.which, e.data.mouseButtonMask)) {
-            return false;
+            return;
         }
 
         var config = cornerstoneTools.arrowAnnotate.getConfiguration();
@@ -385,7 +385,7 @@
 
         // now check to see if there is a handle we can move
         if (!toolData) {
-            return false;
+            return;
         }
 
         if (eventData.handlePressed) {

--- a/src/imageTools/seedAnnotate.js
+++ b/src/imageTools/seedAnnotate.js
@@ -292,7 +292,7 @@
         }
 
         if (e.data && e.data.mouseButtonMask && !cornerstoneTools.isMouseButtonEnabled(eventData.which, e.data.mouseButtonMask)) {
-            return false;
+            return;
         }
 
         var config = cornerstoneTools.seedAnnotate.getConfiguration();
@@ -302,7 +302,7 @@
 
         // now check to see if there is a handle we can move
         if (!toolData) {
-            return false;
+            return;
         }
 
         for (var i = 0; i < toolData.data.length; i++) {

--- a/src/imageTools/textMarker.js
+++ b/src/imageTools/textMarker.js
@@ -156,7 +156,7 @@
         }
 
         if (e.data && e.data.mouseButtonMask && !cornerstoneTools.isMouseButtonEnabled(eventData.which, e.data.mouseButtonMask)) {
-            return false;
+            return;
         }
 
         var config = cornerstoneTools.textMarker.getConfiguration();
@@ -166,7 +166,7 @@
 
         // now check to see if there is a handle we can move
         if (!toolData) {
-            return false;
+            return;
         }
 
         for (var i = 0; i < toolData.data.length; i++) {


### PR DESCRIPTION
jquery stops the event propagation when 'false' is returned and this can break the UI.