### PR TITLE
Bugfix for 'CornerstoneToolsMouseClick'

### DIFF
--- a/src/inputSources/mouseInput.js
+++ b/src/inputSources/mouseInput.js
@@ -2,7 +2,7 @@
 
     'use strict';
 
-    var isClickEvent;
+    var isClickEvent = true;
     var preventClickTimeout;
     var clickDelay = 200;
 


### PR DESCRIPTION
Variable is not initialized, so the first click event is not send