### PR TITLE
Prevent circular reference when single handle

### DIFF
--- a/src/imageTools/freehand.js
+++ b/src/imageTools/freehand.js
@@ -211,7 +211,11 @@
 
         // Connect the end of the drawing to the handle nearest to the click
         if (handleNearby !== undefined){
-            data.handles[config.currentHandle - 1].lines.push(data.handles[handleNearby]);
+            // only save x,y params from nearby handle to prevent circular reference
+            data.handles[config.currentHandle - 1].lines.push({
+                x: data.handles[handleNearby].x,
+                y: data.handles[handleNearby].y
+            });
         }
 
         if (config.modifying) {


### PR DESCRIPTION
When using the freehand tool, if you click to create the first handle, then shift click to freehand draw, then end the shape by clicking the origin point, the resulting annotation object will contain a circular reference within the single handle. This occurs when it tries to close the shape by appending the `handleNearby` object to the same handle's `handle.lines` array. This fix appends a new object copying just the x, y coordinates of `handleNearby`.

The circular reference doesn't cause any problems until you try to serialize the annotations object (i.e. to save to a DB). Both` jQuery.extend()` and `JSON.stringify()` will throw errors.