### PR TITLE
Concat custom tools into stack specific state manager

### DIFF
--- a/src/stateManagement/stackSpecificStateManager.js
+++ b/src/stateManagement/stackSpecificStateManager.js
@@ -70,13 +70,16 @@
 
     var stackStateManagers = [];
 
-    function addStackStateManager(element) {
+    function addStackStateManager(element, otherTools) {
         var oldStateManager = cornerstoneTools.getElementToolStateManager(element);
         if (!oldStateManager) {
             oldStateManager = cornerstoneTools.globalImageIdSpecificToolStateManager;
         }
 
         var stackTools = [ 'stack', 'stackPrefetch', 'playClip', 'volume', 'slab', 'referenceLines', 'crosshairs' ];
+        if (otherTools) {
+          stackTools = stackTools.concat(otherTools)
+        }
         var stackSpecificStateManager = cornerstoneTools.newStackSpecificToolStateManager(stackTools, oldStateManager);
         stackStateManagers.push(stackSpecificStateManager);
         cornerstoneTools.setElementToolStateManager(element, stackSpecificStateManager);


### PR DESCRIPTION
I'm adding a stack specific tool, but even though some examples show usage like:
`cornerstoneTools.addStackStateManager(element, ['stack', 'playClip']);`
the second argument is never used, the function itself has a hardcoded list of tools.

This pull request simply merges the second argument into the list of tools.