### PR TITLE
Scroll error event

### DIFF
--- a/src/util/scrollToIndex.js
+++ b/src/util/scrollToIndex.js
@@ -48,6 +48,8 @@ export default function (element, newImageIdIndex) {
     if (errorLoadingHandler) {
       errorLoadingHandler(element, imageId, error);
     }
+    
+    $(element).trigger('CornerstoneNewImageFailed', { element: element, imageId: imageId, error: error });
   }
 
   if (newImageIdIndex === stackData.currentImageIdIndex) {


### PR DESCRIPTION
added a 'CornerstoneNewImageFailed' event sent when scrolling to the stack failed. This is useful to show an error message to the user in that case.