### PR TITLE
Ignore the exception thrown when the image is loaded by playClip

### DIFF
--- a/src/stackTools/playClip.js
+++ b/src/stackTools/playClip.js
@@ -217,15 +217,19 @@ function playClip (element, framesPerSecond) {
       }
 
       loader.then(function (image) {
-        stackData.currentImageIdIndex = newImageIdIndex;
-        if (stackRenderer) {
-          stackRenderer.currentImageIdIndex = newImageIdIndex;
-          stackRenderer.render(element, stackToolData.data, viewport);
-        } else {
-          cornerstone.displayImage(element, image, viewport);
-        }
-        if (endLoadingHandler) {
-          endLoadingHandler(element, image);
+        try {
+          stackData.currentImageIdIndex = newImageIdIndex;
+          if (stackRenderer) {
+            stackRenderer.currentImageIdIndex = newImageIdIndex;
+            stackRenderer.render(element, stackToolData.data, viewport);
+          } else {
+            cornerstone.displayImage(element, image, viewport);
+          }
+          if (endLoadingHandler) {
+            endLoadingHandler(element, image);
+          }
+        } catch (error) {
+          return;
         }
       }, function (error) {
         const imageId = stackData.imageIds[newImageIdIndex];


### PR DESCRIPTION
Stopping the clip does not stop promises which are in progress, so it sometimes completes loading the image after user displays another series in the viewport. In this case, it cannot find the previous enabled element when the image is loaded, so it throws an exception. This is a quick solution by ignoring the exception, but there might be a better solution which stops the promises that are in progress when the clip is stopped.