### PR TITLE
Add a canCreate option to activate

### DIFF
--- a/src/imageTools/mouseButtonTool.js
+++ b/src/imageTools/mouseButtonTool.js
@@ -22,7 +22,8 @@ export default function (mouseToolInterface) {
     }
 
     const eventData = {
-      mouseButtonMask: mouseEventData.which
+      mouseButtonMask: mouseEventData.which,
+      canCreate: true
     };
 
         // Associate this data with this imageId so we can render it and manipulate it
@@ -77,6 +78,8 @@ export default function (mouseToolInterface) {
   }
 
   function mouseDownActivateCallback (e, eventData) {
+    if (!e.data.canCreate) return false;
+
     if (isMouseButtonEnabled(eventData.which, e.data.mouseButtonMask)) {
       if (mouseToolInterface.addNewMeasurement) {
         mouseToolInterface.addNewMeasurement(eventData);
@@ -242,9 +245,10 @@ export default function (mouseToolInterface) {
   }
 
     // Visible, interactive and can create
-  function activate (element, mouseButtonMask) {
+  function activate (element, mouseButtonMask, canCreate) {
     const eventData = {
-      mouseButtonMask
+      mouseButtonMask,
+      canCreate: !(canCreate===false)
     };
 
     $(element).off('CornerstoneImageRendered', mouseToolInterface.onImageRendered);

--- a/src/imageTools/mouseButtonTool.js
+++ b/src/imageTools/mouseButtonTool.js
@@ -22,7 +22,7 @@ export default function (mouseToolInterface) {
     }
 
     const eventData = {
-      mouseButtonMask: mouseEventData.which,
+      mouseButtonMask: mouseEventData.which
     };
 
         // Associate this data with this imageId so we can render it and manipulate it

--- a/src/imageTools/mouseButtonTool.js
+++ b/src/imageTools/mouseButtonTool.js
@@ -23,7 +23,6 @@ export default function (mouseToolInterface) {
 
     const eventData = {
       mouseButtonMask: mouseEventData.which,
-      canCreate: true
     };
 
         // Associate this data with this imageId so we can render it and manipulate it
@@ -78,7 +77,7 @@ export default function (mouseToolInterface) {
   }
 
   function mouseDownActivateCallback (e, eventData) {
-    if (!e.data.canCreate) return false;
+    if (e.data.canCreate===false) return false;
 
     if (isMouseButtonEnabled(eventData.which, e.data.mouseButtonMask)) {
       if (mouseToolInterface.addNewMeasurement) {


### PR DESCRIPTION
This PR adds a canCreate option to activate (defaults to true).

If canCreate is false, then the tool is activated (visible+interactive) but cannot create.

The common scenario for this is starting all image tools with canCreate=false except for one (the current tool) ie length without canCreate=false

The result will be that all existing angles/roi/etc can be manipulated (moved etc) but drag+down where there's no annotation will create a new length.

This is a much more natural user experience.

If needed I can also update the allTools example.