### PR TITLE
Fix circular dependency

### DIFF
--- a/src/.gitattributes
+++ b/src/.gitattributes
@@ -1,0 +1,8 @@
+# Enforce Unix newlines
+*.css   text eol=lf
+*.html  text eol=lf
+*.js    text eol=lf
+*.json  text eol=lf
+*.less  text eol=lf
+*.md    text eol=lf
+*.yml   text eol=lf

--- a/src/stackTools/stackPrefetch.js
+++ b/src/stackTools/stackPrefetch.js
@@ -1,6 +1,7 @@
 import requestPoolManager from '../requestPool/requestPoolManager';
 import loadHandlerManager from '../stateManagement/loadHandlerManager';
 import { addToolState, getToolState } from '../stateManagement/toolState';
+import { setMaxSimultaneousRequests } from '../util/getMaxSimultaneousRequests';
 
 const toolType = 'stackPrefetch';
 const requestType = 'prefetch';
@@ -296,6 +297,10 @@ function getConfiguration () {
 
 function setConfiguration (config) {
   configuration = config;
+
+  if (config.maxSimultaneousRequests) {
+    setMaxSimultaneousRequests(config.maxSimultaneousRequests);
+  }
 }
 
 // Module/private exports

--- a/src/util/getMaxSimultaneousRequests.js
+++ b/src/util/getMaxSimultaneousRequests.js
@@ -1,4 +1,4 @@
-import stackPrefetch from '../stackTools/stackPrefetch';
+let configMaxSimultaneousRequests;
 
 // Maximum concurrent connections to the same server
 // Information from http://sgdev-blog.blogspot.fr/2014/01/maximum-concurrent-connection-to-same.html
@@ -54,12 +54,13 @@ function getBrowserInfo () {
   return M.join(' ');
 }
 
-function getMaxSimultaneousRequests () {
-  const config = stackPrefetch.getConfiguration();
+function setMaxSimultaneousRequests (newMaxSimultaneousRequests) {
+  configMaxSimultaneousRequests = newMaxSimultaneousRequests;
+}
 
-    // Give preference to user-chosen values
-  if (config.maxSimultaneousRequests) {
-    return config.maxSimultaneousRequests;
+function getMaxSimultaneousRequests () {
+  if (configMaxSimultaneousRequests) {
+    return configMaxSimultaneousRequests;
   }
 
   return getDefaultSimultaneousRequests();
@@ -93,6 +94,7 @@ function isMobileDevice () {
 export {
   getDefaultSimultaneousRequests,
   getMaxSimultaneousRequests,
+  setMaxSimultaneousRequests,
   getBrowserInfo,
   isMobileDevice
 };


### PR DESCRIPTION
Fix the circular dependency in getMaxSimultaneousRequests.js (see https://github.com/chafey/cornerstoneTools/issues/215)

Added a setMaxSimultaneousRequests called from stackPrefetch.js and removed importing stackPrefetch from getMaxSimultaneousRequests.js

Also added .gitattributes to prevent windows/unix cr/lf mismatch