### PR TITLE
Fix for https://github.com/chafey/cornerstoneTools/issues/217 

### DIFF
--- a/src/manipulators/moveNewHandle.js
+++ b/src/manipulators/moveNewHandle.js
@@ -29,8 +29,8 @@ export default function (mouseEventData, toolType, data, handle, doneMovingCallb
   }
 
   function whichMovement (e) {
-    $(element).off('CornerstoneToolsMouseMove');
-    $(element).off('CornerstoneToolsMouseDrag');
+    $(element).off('CornerstoneToolsMouseMove', whichMovement);
+    $(element).off('CornerstoneToolsMouseDrag', whichMovement);
 
     $(element).on('CornerstoneToolsMouseMove', moveCallback);
     $(element).on('CornerstoneToolsMouseDrag', moveCallback);


### PR DESCRIPTION
This PR closes https://github.com/chafey/cornerstoneTools/issues/217

The highlight issue occurred whenever a new annotation was created, all other annotations would not be highlighted when moved over.