### PR TITLE
External imports

### DIFF
--- a/src/cornerstone-core.js
+++ b/src/cornerstone-core.js
@@ -1,7 +1,0 @@
-/*
- * When loading sources directly with <script type="module"> replace the line below with
- *   export * from '../../cornerstone/src/index.js';
- */
-
-export * from 'cornerstone-core';
-

--- a/src/cornerstone-math.js
+++ b/src/cornerstone-math.js
@@ -1,6 +1,0 @@
-/*
- * When loading sources directly with <script type="module"> replace the line below with
- *   export * from '../../cornerstoneMath/src/index.js';
- */
-
-export * from 'cornerstone-math';

--- a/src/externalImports.js
+++ b/src/externalImports.js
@@ -1,0 +1,7 @@
+import * as cornerstone from '../../cornerstone/src/index.js';
+import * as cornerstoneMath from '../../cornerstoneMath/src/index.js';
+
+const $ = window.$;
+const Hammer = window.Hammer;
+
+export { $, Hammer, cornerstone, cornerstoneMath };

--- a/src/externalImportsES6modules.js
+++ b/src/externalImportsES6modules.js
@@ -1,0 +1,6 @@
+import * as $ from 'jquery';
+import * as Hammer from 'hammerjs';
+import * as cornerstone from 'cornerstone-core';
+import * as cornerstoneMath from 'cornerstone-math';
+
+export { $, Hammer, cornerstone, cornerstoneMath };

--- a/src/hammer.js
+++ b/src/hammer.js
@@ -1,7 +1,0 @@
-/*
- * When loading sources directly with <script type="module"> remove the line below
- * (keep only the export line)
- */
-import * as Hammer from 'hammerjs';
-
-export default Hammer;

--- a/src/imageTools/angleTool.js
+++ b/src/imageTools/angleTool.js
@@ -1,5 +1,4 @@
-import * as cornerstone from '../cornerstone-core.js';
-import * as cornerstoneMath from '../cornerstone-math.js';
+import { cornerstone, cornerstoneMath } from '../externalImports.js';
 import mouseButtonTool from './mouseButtonTool.js';
 import touchTool from './touchTool.js';
 import drawTextBox from '../util/drawTextBox.js';

--- a/src/imageTools/arrowAnnotate.js
+++ b/src/imageTools/arrowAnnotate.js
@@ -1,7 +1,5 @@
 /* eslint no-alert:0 */
-import $ from '../jquery.js';
-import * as cornerstone from '../cornerstone-core.js';
-import * as cornerstoneMath from '../cornerstone-math.js';
+import { $, cornerstone, cornerstoneMath } from '../externalImports.js';
 import mouseButtonTool from './mouseButtonTool.js';
 import touchTool from './touchTool.js';
 import drawTextBox from '../util/drawTextBox.js';

--- a/src/imageTools/crosshairs.js
+++ b/src/imageTools/crosshairs.js
@@ -1,5 +1,4 @@
-import $ from '../jquery.js';
-import * as cornerstone from '../cornerstone-core.js';
+import { $, cornerstone } from '../externalImports.js';
 import loadHandlerManager from '../stateManagement/loadHandlerManager.js';
 import { addToolState, getToolState, clearToolState } from '../stateManagement/toolState.js';
 import isMouseButtonEnabled from '../util/isMouseButtonEnabled.js';

--- a/src/imageTools/displayTool.js
+++ b/src/imageTools/displayTool.js
@@ -1,5 +1,4 @@
-import $ from '../jquery.js';
-import * as cornerstone from '../cornerstone-core.js';
+import { $, cornerstone } from '../externalImports.js';
 
 export default function (onImageRendered) {
   let configuration = {};

--- a/src/imageTools/doubleTapTool.js
+++ b/src/imageTools/doubleTapTool.js
@@ -1,4 +1,4 @@
-import $ from '../jquery.js';
+import { $ } from '../externalImports.js';
 
 export default function (doubleTapCallback) {
   const toolInterface = {

--- a/src/imageTools/dragProbe.js
+++ b/src/imageTools/dragProbe.js
@@ -1,5 +1,4 @@
-import $ from '../jquery.js';
-import * as cornerstone from '../cornerstone-core.js';
+import { $, cornerstone } from '../externalImports.js';
 import simpleMouseButtonTool from './simpleMouseButtonTool.js';
 import touchDragTool from './touchDragTool.js';
 import textStyle from '../stateManagement/textStyle.js';

--- a/src/imageTools/ellipticalRoi.js
+++ b/src/imageTools/ellipticalRoi.js
@@ -1,5 +1,4 @@
-import * as cornerstone from '../cornerstone-core.js';
-import * as cornerstoneMath from '../cornerstone-math.js';
+import { cornerstone, cornerstoneMath } from '../externalImports.js';
 import mouseButtonTool from './mouseButtonTool.js';
 import touchTool from './touchTool.js';
 import toolStyle from '../stateManagement/toolStyle.js';

--- a/src/imageTools/freehand.js
+++ b/src/imageTools/freehand.js
@@ -1,6 +1,4 @@
-import $ from '../jquery.js';
-import * as cornerstone from '../cornerstone-core.js';
-import * as cornerstoneMath from '../cornerstone-math.js';
+import { $, cornerstone, cornerstoneMath } from '../externalImports.js';
 import toolStyle from '../stateManagement/toolStyle.js';
 import toolColors from '../stateManagement/toolColors.js';
 import drawHandles from '../manipulators/drawHandles.js';

--- a/src/imageTools/highlight.js
+++ b/src/imageTools/highlight.js
@@ -1,5 +1,4 @@
-import * as cornerstone from '../cornerstone-core.js';
-import * as cornerstoneMath from '../cornerstone-math.js';
+import { cornerstone, cornerstoneMath } from '../externalImports.js';
 import mouseButtonRectangleTool from './mouseButtonRectangleTool.js';
 import touchTool from './touchTool.js';
 import toolStyle from '../stateManagement/toolStyle.js';

--- a/src/imageTools/keyboardTool.js
+++ b/src/imageTools/keyboardTool.js
@@ -1,4 +1,4 @@
-import $ from '../jquery.js';
+import { $ } from '../externalImports.js';
 
 export default function (keyDownCallback) {
   let configuration = {};

--- a/src/imageTools/length.js
+++ b/src/imageTools/length.js
@@ -1,5 +1,4 @@
-import * as cornerstone from '../cornerstone-core.js';
-import * as cornerstoneMath from '../cornerstone-math.js';
+import { cornerstone, cornerstoneMath } from '../externalImports.js';
 import mouseButtonTool from './mouseButtonTool.js';
 import touchTool from './touchTool.js';
 import drawTextBox from '../util/drawTextBox.js';

--- a/src/imageTools/magnify.js
+++ b/src/imageTools/magnify.js
@@ -1,5 +1,4 @@
-import $ from '../jquery.js';
-import * as cornerstone from '../cornerstone-core.js';
+import { $, cornerstone } from '../externalImports.js';
 import touchDragTool from './touchDragTool.js';
 import { getBrowserInfo } from '../util/getMaxSimultaneousRequests.js';
 import isMouseButtonEnabled from '../util/isMouseButtonEnabled.js';

--- a/src/imageTools/mouseButtonRectangleTool.js
+++ b/src/imageTools/mouseButtonRectangleTool.js
@@ -1,5 +1,4 @@
-import $ from '../jquery.js';
-import * as cornerstone from '../cornerstone-core.js';
+import { $, cornerstone } from '../externalImports.js';
 import toolCoordinates from '../stateManagement/toolCoordinates.js';
 import getHandleNearImagePoint from '../manipulators/getHandleNearImagePoint.js';
 import handleActivator from '../manipulators/handleActivator.js';

--- a/src/imageTools/mouseButtonTool.js
+++ b/src/imageTools/mouseButtonTool.js
@@ -1,5 +1,4 @@
-import $ from '../jquery.js';
-import * as cornerstone from '../cornerstone-core.js';
+import { $, cornerstone } from '../externalImports.js';
 import toolCoordinates from '../stateManagement/toolCoordinates.js';
 import getHandleNearImagePoint from '../manipulators/getHandleNearImagePoint.js';
 import handleActivator from '../manipulators/handleActivator.js';

--- a/src/imageTools/mouseWheelTool.js
+++ b/src/imageTools/mouseWheelTool.js
@@ -1,4 +1,4 @@
-import $ from '../jquery.js';
+import { $ } from '../externalImports.js';
 
 export default function (mouseWheelCallback) {
   const toolInterface = {

--- a/src/imageTools/multiTouchDragTool.js
+++ b/src/imageTools/multiTouchDragTool.js
@@ -1,4 +1,4 @@
-import $ from '../jquery.js';
+import { $ } from '../externalImports.js';
 
 export default function (touchDragCallback, options) {
   let configuration = {};

--- a/src/imageTools/pan.js
+++ b/src/imageTools/pan.js
@@ -1,5 +1,4 @@
-import $ from '../jquery.js';
-import * as cornerstone from '../cornerstone-core.js';
+import { $, cornerstone } from '../externalImports.js';
 import simpleMouseButtonTool from './simpleMouseButtonTool.js';
 import touchDragTool from './touchDragTool.js';
 import isMouseButtonEnabled from '../util/isMouseButtonEnabled.js';

--- a/src/imageTools/panMultiTouch.js
+++ b/src/imageTools/panMultiTouch.js
@@ -1,4 +1,4 @@
-import * as cornerstone from '../cornerstone-core.js';
+import { cornerstone } from '../externalImports.js';
 import multiTouchDragTool from './multiTouchDragTool.js';
 
 function touchPanCallback (e, eventData) {

--- a/src/imageTools/probe.js
+++ b/src/imageTools/probe.js
@@ -1,5 +1,4 @@
-import * as cornerstone from '../cornerstone-core.js';
-import * as cornerstoneMath from '../cornerstone-math.js';
+import { cornerstone, cornerstoneMath } from '../externalImports.js';
 import mouseButtonTool from './mouseButtonTool.js';
 import touchTool from './touchTool.js';
 import toolColors from '../stateManagement/toolColors.js';

--- a/src/imageTools/rectangleRoi.js
+++ b/src/imageTools/rectangleRoi.js
@@ -1,5 +1,4 @@
-import * as cornerstone from '../cornerstone-core.js';
-import * as cornerstoneMath from '../cornerstone-math.js';
+import { cornerstone, cornerstoneMath } from '../externalImports.js';
 import mouseButtonTool from './mouseButtonTool.js';
 import touchTool from './touchTool.js';
 import toolStyle from '../stateManagement/toolStyle.js';

--- a/src/imageTools/rotate.js
+++ b/src/imageTools/rotate.js
@@ -1,5 +1,4 @@
-import $ from '../jquery.js';
-import * as cornerstone from '../cornerstone-core.js';
+import { $, cornerstone } from '../externalImports.js';
 import simpleMouseButtonTool from './simpleMouseButtonTool.js';
 import touchDragTool from './touchDragTool.js';
 import isMouseButtonEnabled from '../util/isMouseButtonEnabled.js';

--- a/src/imageTools/rotateTouch.js
+++ b/src/imageTools/rotateTouch.js
@@ -1,5 +1,4 @@
-import $ from '../jquery.js';
-import * as cornerstone from '../cornerstone-core.js';
+import { $, cornerstone } from '../externalImports.js';
 
 function touchRotateCallback (e, eventData) {
   eventData.viewport.rotation += eventData.rotation;

--- a/src/imageTools/saveAs.js
+++ b/src/imageTools/saveAs.js
@@ -1,4 +1,4 @@
-import $ from '../jquery.js';
+import { $ } from '../externalImports.js';
 
 export default function (element, filename) {
   const canvas = $(element).find('canvas').get(0);

--- a/src/imageTools/seedAnnotate.js
+++ b/src/imageTools/seedAnnotate.js
@@ -1,7 +1,5 @@
 /* eslint no-alert:0 */
-import $ from '../jquery.js';
-import * as cornerstone from '../cornerstone-core.js';
-import * as cornerstoneMath from '../cornerstone-math.js';
+import { $, cornerstone, cornerstoneMath } from '../externalImports.js';
 import mouseButtonTool from './mouseButtonTool.js';
 import touchTool from './touchTool.js';
 import drawTextBox from '../util/drawTextBox.js';

--- a/src/imageTools/simpleAngle.js
+++ b/src/imageTools/simpleAngle.js
@@ -1,6 +1,4 @@
-import $ from '../jquery.js';
-import * as cornerstone from '../cornerstone-core.js';
-import * as cornerstoneMath from '../cornerstone-math.js';
+import { $, cornerstone, cornerstoneMath } from '../externalImports.js';
 import mouseButtonTool from './mouseButtonTool.js';
 import drawTextBox from '../util/drawTextBox.js';
 import roundToDecimal from '../util/roundToDecimal.js';

--- a/src/imageTools/simpleMouseButtonTool.js
+++ b/src/imageTools/simpleMouseButtonTool.js
@@ -1,4 +1,4 @@
-import $ from '../jquery.js';
+import { $ } from '../externalImports.js';
 
 export default function (mouseDownCallback) {
   let configuration = {};

--- a/src/imageTools/textMarker.js
+++ b/src/imageTools/textMarker.js
@@ -1,6 +1,4 @@
-import $ from '../jquery.js';
-import * as cornerstone from '../cornerstone-core.js';
-import * as cornerstoneMath from '../cornerstone-math.js';
+import { $, cornerstone, cornerstoneMath } from '../externalImports.js';
 import mouseButtonTool from './mouseButtonTool.js';
 import touchTool from './touchTool.js';
 import pointInsideBoundingBox from '../util/pointInsideBoundingBox.js';

--- a/src/imageTools/touchDragTool.js
+++ b/src/imageTools/touchDragTool.js
@@ -1,4 +1,4 @@
-import $ from '../jquery.js';
+import { $ } from '../externalImports.js';
 
 export default function (touchDragCallback, options) {
   let events = 'CornerstoneToolsTouchDrag';

--- a/src/imageTools/touchPinchTool.js
+++ b/src/imageTools/touchPinchTool.js
@@ -1,4 +1,4 @@
-import $ from '../jquery.js';
+import { $ } from '../externalImports.js';
 
 export default function (touchPinchCallback) {
   const toolInterface = {

--- a/src/imageTools/touchTool.js
+++ b/src/imageTools/touchTool.js
@@ -1,5 +1,4 @@
-import $ from '../jquery.js';
-import * as cornerstone from '../cornerstone-core.js';
+import { $, cornerstone } from '../externalImports.js';
 import anyHandlesOutsideImage from '../manipulators/anyHandlesOutsideImage.js';
 import getHandleNearImagePoint from '../manipulators/getHandleNearImagePoint.js';
 import touchMoveHandle from '../manipulators/touchMoveHandle.js';
@@ -380,5 +379,6 @@ function touchTool (touchToolInterface) {
 
   return toolInterface;
 }
+
 
 export default touchTool;

--- a/src/imageTools/wwwc.js
+++ b/src/imageTools/wwwc.js
@@ -1,5 +1,4 @@
-import $ from '../jquery.js';
-import * as cornerstone from '../cornerstone-core.js';
+import { $, cornerstone } from '../externalImports.js';
 import simpleMouseButtonTool from './simpleMouseButtonTool.js';
 import touchDragTool from './touchDragTool.js';
 import isMouseButtonEnabled from '../util/isMouseButtonEnabled.js';

--- a/src/imageTools/wwwcRegion.js
+++ b/src/imageTools/wwwcRegion.js
@@ -1,5 +1,4 @@
-import $ from '../jquery.js';
-import * as cornerstone from '../cornerstone-core.js';
+import { $, cornerstone } from '../externalImports.js';
 import toolStyle from '../stateManagement/toolStyle.js';
 import toolColors from '../stateManagement/toolColors.js';
 import { getToolState, addToolState } from '../stateManagement/toolState.js';

--- a/src/imageTools/zoom.js
+++ b/src/imageTools/zoom.js
@@ -1,5 +1,4 @@
-import $ from '../jquery.js';
-import * as cornerstone from '../cornerstone-core.js';
+import { $, cornerstone } from '../externalImports.js';
 import simpleMouseButtonTool from './simpleMouseButtonTool.js';
 import isMouseButtonEnabled from '../util/isMouseButtonEnabled.js';
 import mouseWheelTool from './mouseWheelTool.js';

--- a/src/inputSources/keyboardInput.js
+++ b/src/inputSources/keyboardInput.js
@@ -1,5 +1,4 @@
-import $ from '../jquery.js';
-import * as cornerstone from '../cornerstone-core.js';
+import { $, cornerstone } from '../externalImports.js';
 
 let mouseX;
 let mouseY;

--- a/src/inputSources/mouseInput.js
+++ b/src/inputSources/mouseInput.js
@@ -1,6 +1,4 @@
-import $ from '../jquery.js';
-import * as cornerstone from '../cornerstone-core.js';
-import * as cornerstoneMath from '../cornerstone-math.js';
+import { $, cornerstone, cornerstoneMath } from '../externalImports.js';
 import copyPoints from '../util/copyPoints.js';
 import pauseEvent from '../util/pauseEvent.js';
 

--- a/src/inputSources/mouseWheelInput.js
+++ b/src/inputSources/mouseWheelInput.js
@@ -1,5 +1,4 @@
-import $ from '../jquery.js';
-import * as cornerstone from '../cornerstone-core.js';
+import { $, cornerstone } from '../externalImports.js';
 
 function mouseWheel (e) {
     // !!!HACK/NOTE/WARNING!!!

--- a/src/inputSources/preventGhostClick.js
+++ b/src/inputSources/preventGhostClick.js
@@ -1,8 +1,8 @@
- // Functions to prevent ghost clicks following a touch
+import { $ } from '../externalImports.js';
+
+// Functions to prevent ghost clicks following a touch
 // All credit to @kosich
 // https://gist.github.com/kosich/23188dd86633b6c2efb7
-
-import $ from '../jquery.js';
 
 const antiGhostDelay = 2000,
   pointerType = {

--- a/src/inputSources/touchInput.js
+++ b/src/inputSources/touchInput.js
@@ -1,7 +1,4 @@
-import $ from '../jquery.js';
-import Hammer from '../hammer.js';
-import * as cornerstone from '../cornerstone-core.js';
-import * as cornerstoneMath from '../cornerstone-math.js';
+import { $, Hammer, cornerstone, cornerstoneMath } from '../externalImports.js';
 import copyPoints from '../util/copyPoints.js';
 import pauseEvent from '../util/pauseEvent.js';
 import preventGhostClick from '../inputSources/preventGhostClick.js';

--- a/src/jquery.js
+++ b/src/jquery.js
@@ -1,7 +1,0 @@
-/*
- * When loading sources directly with <script type="module"> remove the line below
- * (keep only the export line)
- */
-import $ from 'jquery';
-
-export default $;

--- a/src/manipulators/anyHandlesOutsideImage.js
+++ b/src/manipulators/anyHandlesOutsideImage.js
@@ -1,4 +1,4 @@
-import * as cornerstoneMath from '../cornerstone-math.js';
+import { cornerstoneMath } from '../externalImports.js';
 
 export default function (renderData, handles) {
   const image = renderData.image;

--- a/src/manipulators/drawHandles.js
+++ b/src/manipulators/drawHandles.js
@@ -1,4 +1,4 @@
-import * as cornerstone from '../cornerstone-core.js';
+import { cornerstone } from '../externalImports.js';
 import toolStyle from '../stateManagement/toolStyle.js';
 
 const handleRadius = 6;

--- a/src/manipulators/getHandleNearImagePoint.js
+++ b/src/manipulators/getHandleNearImagePoint.js
@@ -1,5 +1,4 @@
-import * as cornerstone from '../cornerstone-core.js';
-import * as cornerstoneMath from '../cornerstone-math.js';
+import { cornerstone, cornerstoneMath } from '../externalImports.js';
 import pointInsideBoundingBox from '../util/pointInsideBoundingBox.js';
 
 export default function (element, handles, coords, distanceThreshold) {

--- a/src/manipulators/moveAllHandles.js
+++ b/src/manipulators/moveAllHandles.js
@@ -1,5 +1,4 @@
-import $ from '../jquery.js';
-import * as cornerstone from '../cornerstone-core.js';
+import { $, cornerstone } from '../externalImports.js';
 import anyHandlesOutsideImage from './anyHandlesOutsideImage.js';
 import { removeToolState } from '../stateManagement/toolState.js';
 

--- a/src/manipulators/moveHandle.js
+++ b/src/manipulators/moveHandle.js
@@ -1,5 +1,4 @@
-import $ from '../jquery.js';
-import * as cornerstone from '../cornerstone-core.js';
+import { $, cornerstone } from '../externalImports.js';
 
 export default function (mouseEventData, toolType, data, handle, doneMovingCallback, preventHandleOutsideImage) {
   const element = mouseEventData.element;

--- a/src/manipulators/moveNewHandle.js
+++ b/src/manipulators/moveNewHandle.js
@@ -1,5 +1,4 @@
-import $ from '../jquery.js';
-import * as cornerstone from '../cornerstone-core.js';
+import { $, cornerstone } from '../externalImports.js';
 
 export default function (mouseEventData, toolType, data, handle, doneMovingCallback, preventHandleOutsideImage) {
   const element = mouseEventData.element;

--- a/src/manipulators/moveNewHandleTouch.js
+++ b/src/manipulators/moveNewHandleTouch.js
@@ -1,5 +1,4 @@
-import $ from '../jquery.js';
-import * as cornerstone from '../cornerstone-core.js';
+import { $, cornerstone } from '../externalImports.js';
 
 export default function (eventData, toolType, data, handle, doneMovingCallback, preventHandleOutsideImage) {
     // Console.log('moveNewHandleTouch');

--- a/src/manipulators/touchMoveAllHandles.js
+++ b/src/manipulators/touchMoveAllHandles.js
@@ -1,5 +1,4 @@
-import $ from '../jquery.js';
-import * as cornerstone from '../cornerstone-core.js';
+import { $, cornerstone } from '../externalImports.js';
 import anyHandlesOutsideImage from './anyHandlesOutsideImage.js';
 import { removeToolState } from '../stateManagement/toolState.js';
 

--- a/src/manipulators/touchMoveHandle.js
+++ b/src/manipulators/touchMoveHandle.js
@@ -1,5 +1,4 @@
-import $ from '../jquery.js';
-import * as cornerstone from '../cornerstone-core.js';
+import { $, cornerstone } from '../externalImports.js';
 
  /*
  * Define the runAnimation boolean as an object

--- a/src/measurementManager/lineSampleMeasurement.js
+++ b/src/measurementManager/lineSampleMeasurement.js
@@ -1,6 +1,6 @@
-// This object manages a collection of measurements
-import $ from '../jquery.js';
+import { $ } from '../externalImports.js';
 
+// This object manages a collection of measurements
 export default function () {
 
   const that = this;

--- a/src/measurementManager/measurementManager.js
+++ b/src/measurementManager/measurementManager.js
@@ -1,6 +1,6 @@
-// This object manages a collection of measurements
-import $ from '../jquery.js';
+import { $ } from '../externalImports.js';
 
+// This object manages a collection of measurements
 function MeasurementManager () {
   const that = this;
 

--- a/src/orientation/getOrientationString.js
+++ b/src/orientation/getOrientationString.js
@@ -1,4 +1,5 @@
-import * as cornerstoneMath from '../cornerstone-math.js';
+import { cornerstoneMath } from '../externalImports.js';
+
 
 export default function (vector) {
     // Thanks to David Clunie

--- a/src/paintingTools/brush.js
+++ b/src/paintingTools/brush.js
@@ -1,5 +1,4 @@
-import $ from '../jquery.js';
-import * as cornerstone from '../cornerstone-core.js';
+import { $, cornerstone } from '../externalImports.js';
 import mouseButtonTool from '../imageTools/mouseButtonTool.js';
 import isMouseButtonEnabled from '../util/isMouseButtonEnabled.js';
 

--- a/src/referenceLines/referenceLinesTool.js
+++ b/src/referenceLines/referenceLinesTool.js
@@ -1,5 +1,4 @@
-import $ from '../jquery.js';
-import * as cornerstone from '../cornerstone-core.js';
+import { $, cornerstone } from '../externalImports.js';
 import { addToolState, getToolState } from '../stateManagement/toolState.js';
 import renderActiveReferenceLine from './renderActiveReferenceLine.js';
 

--- a/src/referenceLines/renderActiveReferenceLine.js
+++ b/src/referenceLines/renderActiveReferenceLine.js
@@ -1,4 +1,4 @@
-import * as cornerstone from '../cornerstone-core.js';
+import { cornerstone } from '../externalImports.js';
 import calculateReferenceLine from './calculateReferenceLine.js';
 import toolColors from '../stateManagement/toolColors.js';
 import toolStyle from '../stateManagement/toolStyle.js';

--- a/src/requestPool/requestPoolManager.js
+++ b/src/requestPool/requestPoolManager.js
@@ -1,4 +1,4 @@
-import * as cornerstone from '../cornerstone-core.js';
+import { cornerstone } from '../externalImports.js';
 import { getMaxSimultaneousRequests } from '../util/getMaxSimultaneousRequests.js';
 
 const requestPool = {

--- a/src/stackTools/fusionRenderer.js
+++ b/src/stackTools/fusionRenderer.js
@@ -1,4 +1,4 @@
-import * as cornerstone from '../cornerstone-core.js';
+import { cornerstone } from '../externalImports.js';
 
 export default class FusionRenderer {
   constructor () {

--- a/src/stackTools/playClip.js
+++ b/src/stackTools/playClip.js
@@ -1,6 +1,5 @@
 /* eslint no-bitwise:0 */
-import $ from '../jquery.js';
-import * as cornerstone from '../cornerstone-core.js';
+import { $, cornerstone } from '../externalImports.js';
 import loadHandlerManager from '../stateManagement/loadHandlerManager.js';
 import { addToolState, getToolState } from '../stateManagement/toolState.js';
 

--- a/src/stackTools/stackPrefetch.js
+++ b/src/stackTools/stackPrefetch.js
@@ -1,5 +1,4 @@
-import $ from '../jquery.js';
-import * as cornerstone from '../cornerstone-core.js';
+import { $, cornerstone } from '../externalImports.js';
 import requestPoolManager from '../requestPool/requestPoolManager.js';
 import loadHandlerManager from '../stateManagement/loadHandlerManager.js';
 import { addToolState, getToolState } from '../stateManagement/toolState.js';

--- a/src/stackTools/stackScroll.js
+++ b/src/stackTools/stackScroll.js
@@ -1,4 +1,4 @@
-import $ from '../jquery.js';
+import { $ } from '../externalImports.js';
 import touchDragTool from '../imageTools/touchDragTool.js';
 import multiTouchDragTool from '../imageTools/multiTouchDragTool.js';
 import simpleMouseButtonTool from '../imageTools/simpleMouseButtonTool.js';

--- a/src/stateManagement/appState.js
+++ b/src/stateManagement/appState.js
@@ -1,4 +1,4 @@
-import * as cornerstone from '../cornerstone-core.js';
+import { cornerstone } from '../externalImports.js';
 import { globalImageIdSpecificToolStateManager } from './imageIdSpecificStateManager.js';
 import { getElementToolStateManager } from './toolState.js';
 

--- a/src/stateManagement/imageIdSpecificStateManager.js
+++ b/src/stateManagement/imageIdSpecificStateManager.js
@@ -1,4 +1,4 @@
-import * as cornerstone from '../cornerstone-core.js';
+import { cornerstone } from '../externalImports.js';
 
 // This implements an imageId specific tool state management strategy.  This means that
 // Measurements data is tied to a specific imageId and only visible for enabled elements

--- a/src/stateManagement/toolState.js
+++ b/src/stateManagement/toolState.js
@@ -1,5 +1,4 @@
-import $ from '../jquery.js';
-import * as cornerstone from '../cornerstone-core.js';
+import { $, cornerstone } from '../externalImports.js';
 import { globalImageIdSpecificToolStateManager } from './imageIdSpecificStateManager.js';
 
 function getElementToolStateManager (element) {

--- a/src/synchronization/Synchronizer.js
+++ b/src/synchronization/Synchronizer.js
@@ -1,5 +1,4 @@
-import $ from '../jquery.js';
-import * as cornerstone from '../cornerstone-core.js';
+import { $, cornerstone } from '../externalImports.js';
 
 // This object is responsible for synchronizing target elements when an event fires on a source
 // Element

--- a/src/synchronization/panZoomSynchronizer.js
+++ b/src/synchronization/panZoomSynchronizer.js
@@ -1,4 +1,4 @@
-import * as cornerstone from '../cornerstone-core.js';
+import { cornerstone } from '../externalImports.js';
 
 // This function synchronizes the target zoom and pan to match the source
 export default function (synchronizer, sourceElement, targetElement) {

--- a/src/synchronization/stackImageIndexSynchronizer.js
+++ b/src/synchronization/stackImageIndexSynchronizer.js
@@ -1,4 +1,4 @@
-import * as cornerstone from '../cornerstone-core.js';
+import { cornerstone } from '../externalImports.js';
 import { getToolState } from '../stateManagement/toolState.js';
 import loadHandlerManager from '../stateManagement/loadHandlerManager.js';
 

--- a/src/synchronization/stackImagePositionOffsetSynchronizer.js
+++ b/src/synchronization/stackImagePositionOffsetSynchronizer.js
@@ -1,4 +1,4 @@
-import * as cornerstone from '../cornerstone-core.js';
+import { cornerstone } from '../externalImports.js';
 import { getToolState } from '../stateManagement/toolState.js';
 import loadHandlerManager from '../stateManagement/loadHandlerManager.js';
 

--- a/src/synchronization/stackImagePositionSynchronizer.js
+++ b/src/synchronization/stackImagePositionSynchronizer.js
@@ -1,5 +1,4 @@
-import $ from '../jquery.js';
-import * as cornerstone from '../cornerstone-core.js';
+import { $, cornerstone } from '../externalImports.js';
 import { getToolState } from '../stateManagement/toolState.js';
 import loadHandlerManager from '../stateManagement/loadHandlerManager.js';
 

--- a/src/synchronization/stackScrollSynchronizer.js
+++ b/src/synchronization/stackScrollSynchronizer.js
@@ -1,4 +1,4 @@
-import * as cornerstone from '../cornerstone-core.js';
+import { cornerstone } from '../externalImports.js';
 import { getToolState } from '../stateManagement/toolState.js';
 import loadHandlerManager from '../stateManagement/loadHandlerManager.js';
 

--- a/src/synchronization/updateImageSynchronizer.js
+++ b/src/synchronization/updateImageSynchronizer.js
@@ -1,4 +1,4 @@
-import * as cornerstone from '../cornerstone-core.js';
+import { cornerstone } from '../externalImports.js';
 
 // This function causes the target image to be drawn immediately
 export default function (synchronizer, sourceElement, targetElement) {

--- a/src/synchronization/wwwcSynchronizer.js
+++ b/src/synchronization/wwwcSynchronizer.js
@@ -1,4 +1,4 @@
-import * as cornerstone from '../cornerstone-core.js';
+import { cornerstone } from '../externalImports.js';
 
 // This function synchronizes the target element ww/wc to match the source element
 export default function (synchronizer, sourceElement, targetElement) {

--- a/src/timeSeriesTools/incrementTimePoint.js
+++ b/src/timeSeriesTools/incrementTimePoint.js
@@ -1,4 +1,4 @@
-import * as cornerstone from '../cornerstone-core.js';
+import { cornerstone } from '../externalImports.js';
 import { getToolState } from '../stateManagement/toolState.js';
 import loadHandlerManager from '../stateManagement/loadHandlerManager.js';
 

--- a/src/timeSeriesTools/probeTool4D.js
+++ b/src/timeSeriesTools/probeTool4D.js
@@ -1,4 +1,4 @@
-import * as cornerstone from '../cornerstone-core.js';
+import { cornerstone } from '../externalImports.js';
 import mouseButtonTool from '../imageTools/mouseButtonTool.js';
 import drawHandles from '../manipulators/drawHandles.js';
 import setContextToDisplayFontSize from '../util/setContextToDisplayFontSize.js';

--- a/src/timeSeriesTools/timeSeriesScroll.js
+++ b/src/timeSeriesTools/timeSeriesScroll.js
@@ -1,4 +1,4 @@
-import $ from '../jquery.js';
+import { $ } from '../externalImports.js';
 import simpleMouseButtonTool from '../imageTools/simpleMouseButtonTool.js';
 import touchDragTool from '../imageTools/touchDragTool.js';
 import mouseWheelTool from '../imageTools/mouseWheelTool.js';

--- a/src/util/calculateSUV.js
+++ b/src/util/calculateSUV.js
@@ -1,4 +1,4 @@
-import * as cornerstone from '../cornerstone-core.js';
+import { cornerstone } from '../externalImports.js';
 
 // Returns a decimal value given a fractional value
 function fracToDec (fractionalValue) {

--- a/src/util/copyPoints.js
+++ b/src/util/copyPoints.js
@@ -1,4 +1,4 @@
-import * as cornerstoneMath from '../cornerstone-math.js';
+import { cornerstoneMath } from '../externalImports.js';
 
 export default function (points) {
   const page = cornerstoneMath.point.copy(points.page);

--- a/src/util/getLuminance.js
+++ b/src/util/getLuminance.js
@@ -1,4 +1,4 @@
-import * as cornerstone from '../cornerstone-core.js';
+import { cornerstone } from '../externalImports.js';
 
 export default function (element, x, y, width, height) {
   if (!element) {

--- a/src/util/getRGBPixels.js
+++ b/src/util/getRGBPixels.js
@@ -1,4 +1,4 @@
-import * as cornerstone from '../cornerstone-core.js';
+import { cornerstone } from '../externalImports.js';
 
 export default function (element, x, y, width, height) {
   if (!element) {

--- a/src/util/pointInsideBoundingBox.js
+++ b/src/util/pointInsideBoundingBox.js
@@ -1,4 +1,4 @@
-import * as cornerstoneMath from '../cornerstone-math.js';
+import { cornerstoneMath } from '../externalImports.js';
 
 export default function (handle, coords) {
   if (!handle.boundingBox) {

--- a/src/util/pointProjector.js
+++ b/src/util/pointProjector.js
@@ -1,4 +1,4 @@
-import * as cornerstoneMath from '../cornerstone-math.js';
+import { cornerstoneMath } from '../externalImports.js';
 
 // Projects a patient point to an image point
 export function projectPatientPointToImagePlane (patientPoint, imagePlane) {

--- a/src/util/scrollToIndex.js
+++ b/src/util/scrollToIndex.js
@@ -1,5 +1,4 @@
-import $ from '../jquery.js';
-import * as cornerstone from '../cornerstone-core.js';
+import { $, cornerstone } from '../externalImports.js';
 import { getToolState } from '../stateManagement/toolState.js';
 import requestPoolManager from '../requestPool/requestPoolManager.js';
 import loadHandlerManager from '../stateManagement/loadHandlerManager.js';
@@ -22,7 +21,6 @@ export default function (element, newImageIdIndex) {
       stackRenderer = stackRendererData.data[0];
     }
   }
-
   const stackData = toolData.data[0];
 
     // Allow for negative indexing
@@ -53,9 +51,8 @@ export default function (element, newImageIdIndex) {
       stackRenderer.currentImageIdIndex = newImageIdIndex;
       stackRenderer.render(element, toolData.data);
     } else {
-      cornerstone.displayImage(element, image, viewport);
+    cornerstone.displayImage(element, image, viewport);
     }
-
     if (endLoadingHandler) {
       endLoadingHandler(element, image);
     }

--- a/src/util/scrollToIndex.js
+++ b/src/util/scrollToIndex.js
@@ -51,7 +51,7 @@ export default function (element, newImageIdIndex) {
       stackRenderer.currentImageIdIndex = newImageIdIndex;
       stackRenderer.render(element, toolData.data);
     } else {
-    cornerstone.displayImage(element, image, viewport);
+      cornerstone.displayImage(element, image, viewport);
     }
     if (endLoadingHandler) {
       endLoadingHandler(element, image);

--- a/src/util/setContextToDisplayFontSize.js
+++ b/src/util/setContextToDisplayFontSize.js
@@ -1,4 +1,4 @@
-import * as cornerstone from '../cornerstone-core.js';
+import { cornerstone } from '../externalImports.js';
 
  /**
  * Sets the canvas context transformation matrix so it is scaled to show text


### PR DESCRIPTION
This PR removes jquery.js, hammer.js, cornerstone-tools.js, cornerstone-math.js and adds two files: externalImports.js and externalImportsES6modules.js

externalImportsES6modules.js is never used.  When direct loading ES6 modules, simply backup and replace externalImports.js with externalImportsES6modules.js, and replace back before creating a packaged build.

All imports were moved to the beginning of the file as seems to be required by chrome/standard.

(This PR also converts some CRLF to LF which got messed up on the original es6 modules PR.)
