### PR TITLE
replaced imagePlane.colPixelSpacing with imagePlane.columnPixelSpacing

### DIFF
--- a/src/imageTools/length.js
+++ b/src/imageTools/length.js
@@ -77,7 +77,7 @@ function onImageRendered (e, eventData) {
 
   if (imagePlane) {
     rowPixelSpacing = imagePlane.rowPixelSpacing || imagePlane.rowImagePixelSpacing;
-    colPixelSpacing = imagePlane.colPixelSpacing || imagePlane.colImagePixelSpacing;
+    colPixelSpacing = imagePlane.columnPixelSpacing || imagePlane.colImagePixelSpacing;
   } else {
     rowPixelSpacing = image.rowPixelSpacing;
     colPixelSpacing = image.columnPixelSpacing;


### PR DESCRIPTION
Measurements wasn't working on some images due to undefined `imagePlane.colPixelSpacing`, replaced to `imagePlane.columnPixelSpacing`.