### PR TITLE
fix stackscrolling with touch on large image sets

### DIFF
--- a/src/stackTools/stackScroll.js
+++ b/src/stackTools/stackScroll.js
@@ -55,8 +55,8 @@ function dragCallback (e, eventData) {
 
   const config = stackScroll.getConfiguration();
 
-  // The Math.max here makes it easier to mouseDrag-scroll small image stacks
-  let pixelsPerImage = external.$(element).height() / Math.max(stackData.imageIds.length, 8);
+  // The Math.max here makes it easier to mouseDrag-scroll small or really large image stacks
+  let pixelsPerImage = Math.max(2, external.$(element).height() / Math.max(stackData.imageIds.length, 8));
 
   if (config && config.stackScrollSpeed) {
     pixelsPerImage = config.stackScrollSpeed;


### PR DESCRIPTION
This PR fixes touch scrolling for large image sets.

The previous behaviour led to scrolling more than 1 image per pixel if there were more images than the height of the element in pixels, which wasn't a good user experience.

New behaviour is to scroll at most 1 image per 2 pixels, and at least 1 image per 1/8 of the element height.