### PR TITLE
Examples updated to use same naming as cornerstoneWADOImageLoader

### DIFF
--- a/examples/exampleMetaDataProvider.js
+++ b/examples/exampleMetaDataProvider.js
@@ -4,7 +4,7 @@
 
     function metaDataProvider(type, imageId)
     {
-        if(type === 'imagePlane') {
+        if(type === 'imagePlaneModule') {
 
             if (imageId === 'example://1') {
                 return {

--- a/examples/exampleNumberMetaDataProvider.js
+++ b/examples/exampleNumberMetaDataProvider.js
@@ -4,7 +4,7 @@
 
     function metaDataProvider(type, imageId)
     {
-        if(type === 'imagePlane') {
+        if(type === 'imagePlaneModule') {
 
             if (imageId.startsWith('example-n')) {
                 var tokens = imageId.substring(12).split(':');

--- a/examples/layeredImageStacks/index.html
+++ b/examples/layeredImageStacks/index.html
@@ -224,12 +224,12 @@ is used by our example image loader-->
   var renderer = new cornerstoneTools.stackRenderers.FusionRenderer();
   renderer.findImageFn = function(imageIds, targetImageId) {
     var minDistance = 1;
-    var targetImagePlane = cornerstone.metaData.get('imagePlane', targetImageId);
+    var targetImagePlane = cornerstone.metaData.get('imagePlaneModule', targetImageId);
     var imagePositionZ = targetImagePlane.imagePositionPatient.z;
 
     var closest;
     imageIds.forEach(function(imageId) {
-      var imagePlane = cornerstone.metaData.get('imagePlane', imageId);  
+      var imagePlane = cornerstone.metaData.get('imagePlaneModule', imageId);
       var imgPosZ = imagePlane.imagePositionPatient.z;
       var distance = Math.abs(imgPosZ - imagePositionZ);
       if (distance < minDistance) {

--- a/examples/orientation/index.html
+++ b/examples/orientation/index.html
@@ -124,7 +124,7 @@
     function calculateOrientationMarkers(element, viewport) {
         var elementDiv = $(element);
         var enabledElement = cornerstone.getEnabledElement(element);
-        var imagePlaneMetaData = cornerstone.metaData.get('imagePlane', enabledElement.image.imageId);
+        var imagePlaneMetaData = cornerstone.metaData.get('imagePlaneModule', enabledElement.image.imageId);
         console.log(imagePlaneMetaData);
         
         var rowString = cornerstoneTools.orientation.getOrientationString(imagePlaneMetaData.rowCosines);

--- a/examples/petctMetaDataProvider.js
+++ b/examples/petctMetaDataProvider.js
@@ -4,7 +4,7 @@
 
     function metaDataProvider(type, imageId)
     {
-        if(type === 'imagePlane') {
+        if(type === 'imagePlaneModule') {
 
             if (imageId === 'ct://1') {
                 return {

--- a/src/imageTools/crosshairs.js
+++ b/src/imageTools/crosshairs.js
@@ -21,7 +21,7 @@ function chooseLocation (e, eventData) {
   const sourceElement = e.currentTarget;
   const sourceEnabledElement = cornerstone.getEnabledElement(sourceElement);
   const sourceImageId = sourceEnabledElement.image.imageId;
-  const sourceImagePlane = cornerstone.metaData.get('imagePlane', sourceImageId);
+  const sourceImagePlane = cornerstone.metaData.get('imagePlaneModule', sourceImageId);
 
   // Get currentPoints from mouse cursor on selected element
   const sourceImagePoint = eventData.currentPoints.image;
@@ -53,7 +53,7 @@ function chooseLocation (e, eventData) {
 
     // Find within the element's stack the closest image plane to selected location
     stackData.imageIds.forEach(function (imageId, index) {
-      const imagePlane = cornerstone.metaData.get('imagePlane', imageId);
+      const imagePlane = cornerstone.metaData.get('imagePlaneModule', imageId);
       const imagePosition = imagePlane.imagePositionPatient;
       const row = imagePlane.rowCosines.clone();
       const column = imagePlane.columnCosines.clone();

--- a/src/imageTools/length.js
+++ b/src/imageTools/length.js
@@ -73,7 +73,7 @@ function onImageRendered (e, eventData) {
 
   const lineWidth = toolStyle.getToolWidth();
   const config = length.getConfiguration();
-  const imagePlane = cornerstone.metaData.get('imagePlane', image.imageId);
+  const imagePlane = cornerstone.metaData.get('imagePlaneModule', image.imageId);
   let rowPixelSpacing;
   let colPixelSpacing;
 

--- a/src/imageTools/orientationMarkers.js
+++ b/src/imageTools/orientationMarkers.js
@@ -7,7 +7,7 @@ import drawTextBox from '../util/drawTextBox.js';
 function getOrientationMarkers (element) {
   const cornerstone = external.cornerstone;
   const enabledElement = cornerstone.getEnabledElement(element);
-  const imagePlaneMetaData = cornerstone.metaData.get('imagePlane', enabledElement.image.imageId);
+  const imagePlaneMetaData = cornerstone.metaData.get('imagePlaneModule', enabledElement.image.imageId);
 
   if (!imagePlaneMetaData || !imagePlaneMetaData.rowCosines || !imagePlaneMetaData.columnCosines) {
     return;

--- a/src/referenceLines/renderActiveReferenceLine.js
+++ b/src/referenceLines/renderActiveReferenceLine.js
@@ -14,8 +14,8 @@ export default function (context, eventData, targetElement, referenceElement) {
     return;
   }
 
-  const targetImagePlane = cornerstone.metaData.get('imagePlane', targetImage.imageId);
-  const referenceImagePlane = cornerstone.metaData.get('imagePlane', referenceImage.imageId);
+  const targetImagePlane = cornerstone.metaData.get('imagePlaneModule', targetImage.imageId);
+  const referenceImagePlane = cornerstone.metaData.get('imagePlaneModule', referenceImage.imageId);
 
   // Make sure the target and reference actually have image plane metadata
   if (!targetImagePlane ||

--- a/src/synchronization/Synchronizer.js
+++ b/src/synchronization/Synchronizer.js
@@ -40,7 +40,7 @@ function Synchronizer (event, handler) {
       }
 
       const sourceImageId = sourceEnabledElement.image.imageId;
-      const sourceImagePlane = cornerstone.metaData.get('imagePlane', sourceImageId);
+      const sourceImagePlane = cornerstone.metaData.get('imagePlaneModule', sourceImageId);
 
       if (!sourceImagePlane || !sourceImagePlane.imagePositionPatient) {
         return;
@@ -79,7 +79,7 @@ function Synchronizer (event, handler) {
           return;
         }
 
-        const targetImagePlane = cornerstone.metaData.get('imagePlane', targetImageId);
+        const targetImagePlane = cornerstone.metaData.get('imagePlaneModule', targetImageId);
 
         if (!targetImagePlane || !targetImagePlane.imagePositionPatient) {
           return;

--- a/src/synchronization/stackImagePositionOffsetSynchronizer.js
+++ b/src/synchronization/stackImagePositionOffsetSynchronizer.js
@@ -16,7 +16,7 @@ export default function (synchronizer, sourceElement, targetElement, eventData, 
 
   const cornerstone = external.cornerstone;
   const sourceEnabledElement = cornerstone.getEnabledElement(sourceElement);
-  const sourceImagePlane = cornerstone.metaData.get('imagePlane', sourceEnabledElement.image.imageId);
+  const sourceImagePlane = cornerstone.metaData.get('imagePlaneModule', sourceEnabledElement.image.imageId);
   const sourceImagePosition = sourceImagePlane.imagePositionPatient;
 
   const stackToolDataSource = getToolState(targetElement, 'stack');
@@ -32,7 +32,7 @@ export default function (synchronizer, sourceElement, targetElement, eventData, 
   const finalPosition = sourceImagePosition.clone().add(positionDifference);
 
   stackData.imageIds.forEach(function (imageId, index) {
-    const imagePlane = cornerstone.metaData.get('imagePlane', imageId);
+    const imagePlane = cornerstone.metaData.get('imagePlaneModule', imageId);
     const imagePosition = imagePlane.imagePositionPatient;
     const distance = finalPosition.distanceToSquared(imagePosition);
 

--- a/src/synchronization/stackImagePositionSynchronizer.js
+++ b/src/synchronization/stackImagePositionSynchronizer.js
@@ -13,7 +13,7 @@ export default function (synchronizer, sourceElement, targetElement) {
 
   const cornerstone = external.cornerstone;
   const sourceImage = cornerstone.getEnabledElement(sourceElement).image;
-  const sourceImagePlane = cornerstone.metaData.get('imagePlane', sourceImage.imageId);
+  const sourceImagePlane = cornerstone.metaData.get('imagePlaneModule', sourceImage.imageId);
   const sourceImagePosition = sourceImagePlane.imagePositionPatient;
 
   const stackToolDataSource = getToolState(targetElement, 'stack');
@@ -23,7 +23,7 @@ export default function (synchronizer, sourceElement, targetElement) {
   let newImageIdIndex = -1;
 
   external.$.each(stackData.imageIds, function (index, imageId) {
-    const imagePlane = cornerstone.metaData.get('imagePlane', imageId);
+    const imagePlane = cornerstone.metaData.get('imagePlaneModule', imageId);
     const imagePosition = imagePlane.imagePositionPatient;
     const distance = imagePosition.distanceToSquared(sourceImagePosition);
     // Console.log(index + '=' + distance);


### PR DESCRIPTION
This is part of a "bug" fix for https://github.com/chafey/cornerstoneTools/issues/242
(Really more of a small update to remain consistent)

The other half is adding the fields required for the reference line tool to work to the WADORS/WADOURI image loaders. You can find a working implementation on the OHIF viewer:

https://github.com/OHIF/Viewers/blob/de5fe8d5346481c534234865f00c70f41403c31a/Packages/ohif-cornerstone/client/lib/classes/MetadataProvider.js#L249-L259

*Missing fields for WADORS:*

- frameOfReferenceUID
- rowCosines
- columnCosines

*Missing fields for WADOURI:*

- rowCosines
- columnCosines

I probably didn't miss anything. Cheers, @swederik 